### PR TITLE
Fixes class cast exception

### DIFF
--- a/waltz-data/src/main/java/com/khartec/waltz/data/server_information/ServerInformationDao.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/server_information/ServerInformationDao.java
@@ -297,7 +297,7 @@ public class ServerInformationDao {
                 .stream()
                 .map(r -> ImmutableTally.<String>builder()
                         .id(r.get(SERVER_USAGE.ENVIRONMENT))
-                        .count(r.get(countField))
+                        .count(r.get(countField, Double.class))
                         .build())
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
- looks like DSL.count() in this usage returns a long not an integer as claimed by the type signature.....

#5153