### PR TITLE
Report grid can now reference people (via involvements)

### DIFF
--- a/waltz-model/src/main/java/com/khartec/waltz/model/report_grid/ReportGridCell.java
+++ b/waltz-model/src/main/java/com/khartec/waltz/model/report_grid/ReportGridCell.java
@@ -1,3 +1,21 @@
+/*
+ * Waltz - Enterprise Architecture
+ * Copyright (C) 2016, 2017, 2018, 2019 Waltz open source project
+ * See README.md for more information
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific
+ *
+ */
+
 package com.khartec.waltz.model.report_grid;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -24,5 +42,8 @@ public abstract class ReportGridCell implements CommentProvider {
 
     @Nullable
     public abstract BigDecimal value();
+
+    @Nullable
+    public abstract String text();
 
 }

--- a/waltz-ng/client/common/components/grid/grid.scss
+++ b/waltz-ng/client/common/components/grid/grid.scss
@@ -58,8 +58,10 @@
         overflow-y: auto;
     }
 
-    .waltz-grid-color-cell {
-        padding: 5px;
+    .waltz-grid-report-cell {
+        padding-left: 5px;
+        padding-right: 5px;
+        padding-top: 8px;
         margin: 1px;
         -moz-box-sizing: border-box;
         -webkit-box-sizing: border-box;

--- a/waltz-ng/client/report-grid/components/report-grid-view-panel/report-grid-view-panel.js
+++ b/waltz-ng/client/report-grid/components/report-grid-view-panel/report-grid-view-panel.js
@@ -89,7 +89,7 @@ function prepareColumnDefs(gridData) {
                 return {
                     allowSummary: false,
                     cellTemplate:`
-                        <div class="waltz-grid-color-cell"
+                        <div class="waltz-grid-report-cell"
                              style="text-align: right"
                              ng-style="{
                                 'background-color': COL_FIELD.color,
@@ -103,8 +103,7 @@ function prepareColumnDefs(gridData) {
                     width: 150,
                     toSearchTerm: d => _.get(d, [mkPropNameForRef(c.columnEntityReference), "text"], ""),
                     cellTemplate:`
-                        <div class="waltz-grid-color-cell"
-                             style="text-align: right">
+                        <div class="waltz-grid-report-cell">
                             <span ng-bind="COL_FIELD.text"></span>
                         </div>`
                 };
@@ -113,7 +112,7 @@ function prepareColumnDefs(gridData) {
                     allowSummary: true,
                     toSearchTerm: d => _.get(d, [mkPropNameForRef(c.columnEntityReference), "name"], ""),
                     cellTemplate:
-                        `<div class="waltz-grid-color-cell"
+                        `<div class="waltz-grid-report-cell"
                               ng-bind="COL_FIELD.name"
                               uib-popover-html="COL_FIELD.comment"
                               popover-trigger="mouseenter"

--- a/waltz-ng/client/report-grid/components/report-grid-view-panel/report-grid-view-panel.js
+++ b/waltz-ng/client/report-grid/components/report-grid-view-panel/report-grid-view-panel.js
@@ -1,3 +1,21 @@
+/*
+ * Waltz - Enterprise Architecture
+ * Copyright (C) 2016, 2017, 2018, 2019 Waltz open source project
+ * See README.md for more information
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific
+ *
+ */
+
 import template from "./report-grid-view-panel.html";
 import {initialiseData} from "../../../common";
 import {mkEntityLinkGridCell} from "../../../common/grid-utils";
@@ -71,17 +89,29 @@ function prepareColumnDefs(gridData) {
                 return {
                     allowSummary: false,
                     cellTemplate:`
-                    <div class="waltz-grid-color-cell"
-                    style="text-align: right"
-                         ng-style="{
-                            'background-color': COL_FIELD.color,
-                            'color': COL_FIELD.fontColor}">
-                            <waltz-currency-amount amount="COL_FIELD.value"></waltz-currency-amount>
-                    </div>`
+                        <div class="waltz-grid-color-cell"
+                             style="text-align: right"
+                             ng-style="{
+                                'background-color': COL_FIELD.color,
+                                'color': COL_FIELD.fontColor}">
+                                <waltz-currency-amount amount="COL_FIELD.value"></waltz-currency-amount>
+                        </div>`
+                };
+            case 'INVOLVEMENT_KIND':
+                return {
+                    allowSummary: false,
+                    width: 150,
+                    toSearchTerm: d => _.get(d, [mkPropNameForRef(c.columnEntityReference), "text"], ""),
+                    cellTemplate:`
+                        <div class="waltz-grid-color-cell"
+                             style="text-align: right">
+                            <span ng-bind="COL_FIELD.text"></span>
+                        </div>`
                 };
             default:
                 return {
                     allowSummary: true,
+                    toSearchTerm: d => _.get(d, [mkPropNameForRef(c.columnEntityReference), "name"], ""),
                     cellTemplate:
                         `<div class="waltz-grid-color-cell"
                               ng-bind="COL_FIELD.name"
@@ -93,18 +123,17 @@ function prepareColumnDefs(gridData) {
                               popover-placement="left"
                               ng-style="{
                                 'border-bottom-right-radius': COL_FIELD.comment ? '15% 50%' : 0,
-                                'background-color': COL_FIELD.color, 
+                                'background-color': COL_FIELD.color,
                                 'color': COL_FIELD.fontColor}">
-                        </div>`}
+                        </div>`
+                };
         }
     };
-
 
     const additionalColumns = _
         .chain(colDefs)
         .map(c => {
             return Object.assign(
-                mkColumnCustomProps(c),
                 {
                     field: mkPropNameForRef(c.columnEntityReference),
                     displayName: c.columnEntityReference.name,
@@ -112,7 +141,8 @@ function prepareColumnDefs(gridData) {
                     width: 100,
                     headerTooltip: c.columnEntityReference.description,
                     enableSorting: false
-                })
+                },
+                mkColumnCustomProps(c));
         })
         .value();
 
@@ -170,6 +200,9 @@ function prepareTableData(gridData) {
                 return {
                     color: color,
                     value: x.value };
+            case 'INVOLVEMENT_KIND':
+                return {
+                    text: x.text };
             default:
                 const ratingSchemeItem = ratingSchemeItemsById[x.ratingId];
                 const popoverHtml = mkPopoverHtml(x, ratingSchemeItem);

--- a/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/ReportGridExtractor.java
+++ b/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/extracts/ReportGridExtractor.java
@@ -15,7 +15,6 @@
  * See the License for the specific
  *
  */
-
 package com.khartec.waltz.web.endpoints.extracts;
 
 import com.khartec.waltz.model.EntityKind;
@@ -91,7 +90,9 @@ public class ReportGridExtractor implements DataExtractor {
                                                                 long gridId,
                                                                 IdSelectionOptions selectionOptions) throws IOException {
 
-        ReportGrid reportGrid = reportGridService.getByIdAndSelectionOptions(gridId, selectionOptions);
+        ReportGrid reportGrid = reportGridService.getByIdAndSelectionOptions(
+                gridId,
+                selectionOptions);
 
         List<Tuple2<Application, ArrayList<Object>>> reportRows = prepareReportRows(reportGrid);
 
@@ -117,7 +118,9 @@ public class ReportGridExtractor implements DataExtractor {
                 "Application Name",
                 "Application Asset Code");
 
-        List<String> columnHeaders = map(columnDefinitions, r -> r.columnEntityReference().name().get());
+        List<String> columnHeaders = map(
+                columnDefinitions,
+                r -> r.columnEntityReference().name().get());
 
         return concat(
                 staticHeaders,
@@ -132,7 +135,9 @@ public class ReportGridExtractor implements DataExtractor {
         Map<Long, Application> applicationsById = indexById(reportGrid.instance().applications());
         Map<Long, RagName> ratingsById = indexById(reportGrid.instance().ratingSchemeItems());
 
-        Map<Long, Collection<ReportGridCell>> tableDataByAppId = groupBy(tableData, ReportGridCell::applicationId);
+        Map<Long, Collection<ReportGridCell>> tableDataByAppId = groupBy(
+                tableData,
+                ReportGridCell::applicationId);
 
         return tableDataByAppId
                 .entrySet()
@@ -143,7 +148,8 @@ public class ReportGridExtractor implements DataExtractor {
 
                     ArrayList<Object> reportRow = new ArrayList<>();
 
-                    Map<Tuple2<Long, EntityKind>, Object> callValuesByColumnRefForApp = indexBy(r.getValue(),
+                    Map<Tuple2<Long, EntityKind>, Object> callValuesByColumnRefForApp = indexBy(
+                            r.getValue(),
                             k -> tuple(k.columnEntityId(), k.columnEntityKind()),
                             v -> getValueFromReportRow(ratingsById, v));
 
@@ -152,7 +158,9 @@ public class ReportGridExtractor implements DataExtractor {
                             .columnDefinitions()
                             .forEach(colDef -> reportRow.add(
                                     callValuesByColumnRefForApp.getOrDefault(
-                                              tuple(colDef.columnEntityReference().id(), colDef.columnEntityReference().kind()),
+                                            tuple(
+                                                colDef.columnEntityReference().id(),
+                                                colDef.columnEntityReference().kind()),
                                             null)));
                     return tuple(app, reportRow);
                 })
@@ -161,7 +169,8 @@ public class ReportGridExtractor implements DataExtractor {
     }
 
 
-    private Object getValueFromReportRow(Map<Long, RagName> ratingsById, ReportGridCell reportGridCell) {
+    private Object getValueFromReportRow(Map<Long, RagName> ratingsById,
+                                         ReportGridCell reportGridCell) {
         switch (reportGridCell.columnEntityKind()){
             case COST_KIND:
                 return reportGridCell.value();


### PR DESCRIPTION
Adding involvement support on grid reports

- Configure via adding an `INVOLVEMENT_KIND` record as a `report_grid_column_definition`
- Bonus: search can now be used over ratings and person cells
- Bonus: renamed some methods in the `ReportGridDao` to improve clarity 

#5224 
