### PR TITLE
Fix section jumping inconsistencies

### DIFF
--- a/waltz-ng/client/dynamic-section/components/dynamic-section-navigation/dynamic-section-navigation.js
+++ b/waltz-ng/client/dynamic-section/components/dynamic-section-navigation/dynamic-section-navigation.js
@@ -55,7 +55,7 @@ function controller(dynamicSectionManager,
                 vm.stickyVisible = $window.pageYOffset > vm.offset;
             });
         },
-        150);
+        300);
 
     function enableScrollListener() {
         angular
@@ -99,7 +99,8 @@ function controller(dynamicSectionManager,
 
     vm.onSelect = (section) => {
         dynamicSectionManager.activate(section);
-        $window.scrollTo(0, vm.offset);
+        const elem = document.getElementById('page-top');
+        elem.scrollIntoView()
     };
 
 }

--- a/waltz-ng/client/dynamic-section/components/dynamic-section-wrapper/dynamic-section-wrapper.html
+++ b/waltz-ng/client/dynamic-section/components/dynamic-section-wrapper/dynamic-section-wrapper.html
@@ -16,7 +16,8 @@
   ~
   -->
 
-<!-- if we are rendering a svelte component -->
+<!-- if we are rendering a svelte component,
+     for pure angular components we are including them via $compile -->
 <waltz-dynamic-section ng-if="$ctrl.section.svelteComponent"
                        parent-entity-ref="$ctrl.parentEntityRef"
                        class="waltz-dynamic-section waltz-dynamic-section-render-mode-standard waltz-dynamic-section-${section.id}"

--- a/waltz-ng/client/dynamic-section/components/dynamic-section-wrapper/dynamic-section-wrapper.js
+++ b/waltz-ng/client/dynamic-section/components/dynamic-section-wrapper/dynamic-section-wrapper.js
@@ -48,7 +48,7 @@ function controller($element, $compile, $scope) {
         vm.sectionScope.onRemove = vm.onRemove;
         vm.sectionScope.canRemove = vm.canRemove;
 
-        if (vm.section.componentId) {
+        if (vm.section.componentId && !vm.section.svelteComponent) {
             const linkFn = $compile(sectionToTemplate(vm.section, vm.renderMode));
             const content = linkFn(vm.sectionScope);
             $element.append(content);

--- a/waltz-ng/client/dynamic-section/components/dynamic-sections-view/dynamic-sections-view.html
+++ b/waltz-ng/client/dynamic-section/components/dynamic-sections-view/dynamic-sections-view.html
@@ -18,8 +18,11 @@
 
 <div class="waltz-dynamic-sections-view">
 
-    <div ng-repeat="section in $ctrl.sections track by section.id"
-         class='waltz-animate-repeat'>
+    <!-- we jump to this anchor when opening a new section -->
+    <a id="page-top" class="waltz-page-top-anchor"></a>
+
+    <div class="waltz-animate-repeat"
+         ng-repeat="section in $ctrl.sections track by section.id">
         <waltz-dynamic-section-wrapper section="section"
                                        on-remove="$ctrl.onRemove"
                                        parent-entity-ref="$ctrl.parentEntityRef"

--- a/waltz-ng/client/dynamic-section/components/dynamic-sections-view/waltz-dynamic-sections-view.scss
+++ b/waltz-ng/client/dynamic-section/components/dynamic-sections-view/waltz-dynamic-sections-view.scss
@@ -61,6 +61,6 @@
 .waltz-page-top-anchor {
     display: block;
     position: relative;
-    top: -120px;
+    top: -130px;
     visibility: hidden;
 }

--- a/waltz-ng/client/dynamic-section/components/dynamic-sections-view/waltz-dynamic-sections-view.scss
+++ b/waltz-ng/client/dynamic-section/components/dynamic-sections-view/waltz-dynamic-sections-view.scss
@@ -57,3 +57,10 @@
     }
 
 }
+
+.waltz-page-top-anchor {
+    display: block;
+    position: relative;
+    top: -120px;
+    visibility: hidden;
+}

--- a/waltz-ng/client/dynamic-section/dynamic-section-definitions.js
+++ b/waltz-ng/client/dynamic-section/dynamic-section-definitions.js
@@ -48,6 +48,7 @@ const authSourcesSection = {
 
 const bookmarksSection = {
     svelteComponent: BookmarkPanel,
+    componentId: "bookmarks-section",
     name: "Bookmarks",
     icon: "rocket",
     id: 5,

--- a/waltz-ng/client/physical-flows/components/physical-flow-section/physical-flow-section.html
+++ b/waltz-ng/client/physical-flows/components/physical-flow-section/physical-flow-section.html
@@ -15,7 +15,8 @@
   ~ See the License for the specific
   ~
   -->
-<p>This
+<p>
+    This
     <span ng-bind="$ctrl.parentEntityRef.kind | toDisplayName: 'entity'"></span>
     is associated to the following physical flows:
 </p>

--- a/waltz-ng/client/physical-specifications/components/physical-data-section/physical-data-section.html
+++ b/waltz-ng/client/physical-specifications/components/physical-data-section/physical-data-section.html
@@ -59,9 +59,9 @@
             <br><br>
 
             <waltz-grid-with-search column-defs="$ctrl.columnDefs"
-                                     entries="$ctrl.gridData"
-                                     search-control-min-rows="0"
-                                     class="small">
+                                    entries="$ctrl.gridData"
+                                    search-control-min-rows="0"
+                                    class="small">
             </waltz-grid-with-search>
             <hr>
         </div>


### PR DESCRIPTION
Jumping between sections can be frustrating at times. This is due to the dynamic size of the header sections. A simple approach is to use a fixed a anchor and jump to that.

#5413