### PR TITLE
Attestation fixes

### DIFF
--- a/waltz-data/src/main/java/com/khartec/waltz/data/attestation/AttestationInstanceDao.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/attestation/AttestationInstanceDao.java
@@ -265,7 +265,7 @@ public class AttestationInstanceDao {
                 .firstValue(ATTESTATION_INSTANCE.ID)
                 .over()
                 .partitionBy(ATTESTATION_RUN.ATTESTED_ENTITY_ID)
-                .orderBy(ATTESTATION_INSTANCE.ATTESTED_AT.desc())
+                .orderBy(ATTESTATION_INSTANCE.ATTESTED_AT.desc().nullsLast())
                 .as("latest_attestation");
 
         Table<Record> attestationsWithCategory = dsl

--- a/waltz-ng/client/attestation/attestation-instance-list-user-view.js
+++ b/waltz-ng/client/attestation/attestation-instance-list-user-view.js
@@ -116,7 +116,6 @@ function controller($q,
 
     vm.onCancelAttestation = () => {
         vm.selectedAttestation = null;
-        vm.attestNext = false;
     };
 
     vm.onToggleFilter = () => {


### PR DESCRIPTION
- gives last attested instance priority when showing recent attestations (uses `ORDER BY ... NULLS LAST`)
- 'continue to next attestation' toggle remembers choice when cancelling

#5615
#5617