### PR TITLE
Attestations: closing instances fails for logical and physical flows

### DIFF
--- a/waltz-data/src/main/java/com/khartec/waltz/data/attestation/AttestationInstanceDao.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/attestation/AttestationInstanceDao.java
@@ -241,7 +241,9 @@ public class AttestationInstanceDao {
                 .on(ATTESTATION_INSTANCE_RECIPIENT.ATTESTATION_INSTANCE_ID.eq(ATTESTATION_INSTANCE.ID))
                 .where(ATTESTATION_INSTANCE_RECIPIENT.USER_ID.eq(userId))
                 .and(ATTESTATION_RUN.ATTESTED_ENTITY_KIND.eq(command.attestedEntityKind().name())
-                .and(ATTESTATION_RUN.ATTESTED_ENTITY_ID.eq(command.attestedEntityId()))
+                .and(command.attestedEntityId() == null
+                        ? DSL.trueCondition()
+                        : ATTESTATION_RUN.ATTESTED_ENTITY_ID.eq(command.attestedEntityId()))
                 .and(ATTESTATION_INSTANCE.PARENT_ENTITY_ID.eq(command.entityReference().id()))
                 .and(ATTESTATION_INSTANCE.PARENT_ENTITY_KIND.eq(command.entityReference().kind().name())))
                 .and(maybeUnattestedOnlyCondition)


### PR DESCRIPTION
Root cause: assumption that the run has an attested_entity_id - this is only for measurable attestations (i.e the category id).
This in turn caused the sql to not match on the run and therefore it creates a new run/instance on the fly rather than closing the existing one.

#5661