### PR TITLE
Adding missing from statement to logical flow decorator

### DIFF
--- a/waltz-data/src/main/java/com/khartec/waltz/data/datatype_decorator/LogicalFlowDecoratorDao.java
+++ b/waltz-data/src/main/java/com/khartec/waltz/data/datatype_decorator/LogicalFlowDecoratorDao.java
@@ -121,6 +121,7 @@ public class LogicalFlowDecoratorDao extends DataTypeDecoratorDao {
         return dsl
                 .select(LOGICAL_FLOW_DECORATOR.fields())
                 .select(ENTITY_NAME_FIELD)
+                .from(LOGICAL_FLOW_DECORATOR)
                 .where(LOGICAL_FLOW_DECORATOR.LOGICAL_FLOW_ID.eq(flowId))
                 .and(LOGICAL_FLOW_DECORATOR.DECORATOR_ENTITY_KIND.eq(DATA_TYPE.name()))
                 .and(LOGICAL_FLOW_DECORATOR.DECORATOR_ENTITY_ID.eq(dataTypeId))
@@ -175,6 +176,7 @@ public class LogicalFlowDecoratorDao extends DataTypeDecoratorDao {
         return dsl
                 .select(LOGICAL_FLOW_DECORATOR.fields())
                 .select(ENTITY_NAME_FIELD)
+                .from(LOGICAL_FLOW_DECORATOR)
                 .fetch(TO_DECORATOR_MAPPER);
     }
 
@@ -184,6 +186,7 @@ public class LogicalFlowDecoratorDao extends DataTypeDecoratorDao {
         return dsl
                 .select(LOGICAL_FLOW_DECORATOR.fields())
                 .select(ENTITY_NAME_FIELD)
+                .from(LOGICAL_FLOW_DECORATOR)
                 .where(LOGICAL_FLOW_DECORATOR.LOGICAL_FLOW_ID.eq(entityId))
                 .fetch(TO_DECORATOR_MAPPER);
     }


### PR DESCRIPTION
- caused by refactoring: `selectFrom(...)` to a `select(...)` and then missing the `.from(...)`

#5668