### PR TITLE
Improving attestation error handling

### DIFF
--- a/waltz-common/src/main/java/com/khartec/waltz/common/Checks.java
+++ b/waltz-common/src/main/java/com/khartec/waltz/common/Checks.java
@@ -21,6 +21,7 @@ package com.khartec.waltz.common;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 public class Checks {
 
@@ -121,9 +122,18 @@ public class Checks {
         throw mkFail(msg, args);
     }
 
+
     public static IllegalArgumentException mkFail(String msg, Object... args) {
         throw new IllegalArgumentException(String.format(msg, args));
     }
 
 
+    public static <T> void checkEmpty(Collection<T> ts, Supplier<String> messageSupplier) {
+        checkTrue(CollectionUtilities.isEmpty(ts), messageSupplier.get());
+    }
+
+
+    public static <T> void checkEmpty(Collection<T> ts, String message) {
+        checkTrue(CollectionUtilities.isEmpty(ts), message);
+    }
 }

--- a/waltz-ng/client/attestation/components/confirmation/attestation-confirmation.js
+++ b/waltz-ng/client/attestation/components/confirmation/attestation-confirmation.js
@@ -79,7 +79,8 @@ function controller($q, serviceBroker) {
             return;
         }
         vm.attesting = true;
-        invokeFunction(vm.onConfirm, attestation);
+        vm.onConfirm(attestation)
+            .finally(() => vm.attesting = false);
     };
 
     vm.cancel = () => {

--- a/waltz-ng/client/attestation/components/section/attestation-section.js
+++ b/waltz-ng/client/attestation/components/section/attestation-section.js
@@ -156,13 +156,15 @@ function controller($q,
     vm.attestEntity = () => {
         const msg = "By clicking 'OK', you are attesting that all data flows are present, correct and accurately reflected for this entity, and thereby accountable for this validation.";
         if (confirm(msg)){
-            attest(serviceBroker, vm.parentEntityRef, vm.activeAttestationSection.type)
+            return attest(serviceBroker, vm.parentEntityRef, vm.activeAttestationSection.type)
                 .then(() => {
                     toasts.success("Attested successfully");
                     loadAttestationData(vm.parentEntityRef);
                     vm.onCancelAttestation();
                 })
                 .catch(e => displayError("Could not attest", e));
+        } else {
+            return Promise.resolve();
         }
     };
 

--- a/waltz-service/src/main/java/com/khartec/waltz/service/attestation/AttestationInstanceService.java
+++ b/waltz-service/src/main/java/com/khartec/waltz/service/attestation/AttestationInstanceService.java
@@ -18,6 +18,7 @@
 
 package com.khartec.waltz.service.attestation;
 
+import com.khartec.waltz.common.Checks;
 import com.khartec.waltz.common.StringUtilities;
 import com.khartec.waltz.common.exception.UpdateFailedException;
 import com.khartec.waltz.data.GenericSelector;
@@ -45,11 +46,11 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
 
-import static com.khartec.waltz.common.Checks.checkNotEmpty;
-import static com.khartec.waltz.common.Checks.checkNotNull;
+import static com.khartec.waltz.common.Checks.*;
 import static com.khartec.waltz.common.CollectionUtilities.first;
 import static com.khartec.waltz.common.CollectionUtilities.notEmpty;
 import static com.khartec.waltz.common.DateTimeUtilities.*;
+import static com.khartec.waltz.common.StringUtilities.join;
 import static com.khartec.waltz.schema.Tables.APPLICATION;
 import static java.lang.String.format;
 
@@ -212,8 +213,11 @@ public class AttestationInstanceService {
 
     private void checkLogicalFlowsCanBeAttested(AttestEntityCommand createCommand) {
         List<String> failures = attestationPreCheckService.calcLogicalFlowPreCheckFailures(createCommand.entityReference());
-        String warningString = StringUtilities.join(failures, ";");
-        checkNotEmpty(failures, format("Logical flow check failed with the following warnings: %s", warningString));
+        checkEmpty(
+                failures,
+                () -> format(
+                        "Logical flow check failed with the following warnings: %s",
+                        join(failures, ";")));
     }
 
 

--- a/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/EndpointUtilities.java
+++ b/waltz-web/src/main/java/com/khartec/waltz/web/endpoints/EndpointUtilities.java
@@ -21,9 +21,7 @@ package com.khartec.waltz.web.endpoints;
 import com.khartec.waltz.web.DatumRoute;
 import com.khartec.waltz.web.ListRoute;
 import com.khartec.waltz.web.WebUtilities;
-import spark.ResponseTransformer;
-import spark.Route;
-import spark.Spark;
+import spark.*;
 
 import static com.khartec.waltz.web.WebUtilities.TYPE_JSON;
 
@@ -81,6 +79,18 @@ public class EndpointUtilities {
         Spark.put(path, wrapListHandler(handler), transformer);
     }
 
+    public static <T extends Exception> void addExceptionHandler(Class<T> exceptionClass, ExceptionHandler<T> handler) {
+        Spark.exception(exceptionClass, handler);
+
+        ExceptionHandlerImpl<T> servletExceptionHandler = new ExceptionHandlerImpl<T>(exceptionClass) {
+            @Override
+            public void handle(T exception, Request request, Response response) {
+                handler.handle(exception, request, response);
+            }
+        };
+
+        ExceptionMapper.getInstance().map(exceptionClass, servletExceptionHandler);
+    }
 
     // -- helpers ---
 


### PR DESCRIPTION
- Fixed problem with Spark where exceptions not being handled
  correctly when deployed on tomcat.
  - solution is to dual register the handlers, once in embedded spark
    and once in 'servlet container' spark (i.e. tomcat)

#5725