### PR TITLE
Ensure github release action publishes the `waltz-web-jar-with-depend…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,4 +67,4 @@ jobs:
         files: |
           waltz-data/target/liquibase-scripts.zip
           waltz-web/target/waltz-web.war
-
+          waltz-web/target/waltz-web-jar-with-dependencies.jar


### PR DESCRIPTION
…encies.jar`

#5728