### PR TITLE
dockerize waltz

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,12 +4,12 @@
 name: Waltz Build (pg)
 
 on: push
-      
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     services:
       postgres:
         image: postgres:11
@@ -55,14 +55,41 @@ jobs:
       with:
         name: liquibase-changelogs
         path: waltz-data/src/main/ddl/liquibase/
-    
+
     - name: Publish Test Report
       if: ${{ always() }}
       uses: scacap/action-surefire-report@v1
 
+    - name: Login to GitHub Registry
+      if: ${{ github.ref_type == 'tag' }}
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ghcr.io/${{ github.repository }}
+        flavor: latest=true
+        tags: |
+          type=ref,event=tag,enable=${{ github.ref_type == 'tag' }}
+          type=raw,value=postgres-${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
+          type=raw,value=postgres
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: ${{ github.ref_type == 'tag' }}
+        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.meta.outputs.tags }}
+
     - name: Release
       uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
+      if: ${{ github.ref_type == 'tag' }}
       with:
         files: |
           waltz-data/target/liquibase-scripts.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM tomcat:8-jre8-temurin
+
+ENV PATH="/usr/local/bin/liquibase:${PATH}" 
+
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY ./waltz-data/src/main/ddl/liquibase/*.xml /opt/waltz/liquibase/
+COPY ./waltz-web/target/waltz-web.war /usr/local/tomcat/webapps/ROOT.war
+COPY docker/waltz.properties /home/waltz/.waltz/waltz-template
+COPY waltz-web/src/main/resources/logback.example.xml /home/waltz/.waltz/waltz-logback.xml
+
+RUN useradd -ms /bin/bash waltz && \
+  mkdir -p /opt/waltz/liquibase /opt/liquibase && \
+  chown -R waltz:waltz /usr/local/tomcat /opt/waltz/liquibase /home/waltz/.waltz /opt/liquibase /home/waltz/.waltz/waltz-template && \
+  curl -sLO https://github.com/liquibase/liquibase-package-manager/releases/download/v0.1.2/lpm-0.1.2-linux.zip && \
+  curl -sLO https://github.com/liquibase/liquibase/releases/download/v4.5.0/liquibase-4.5.0.zip && \
+  apt-get update && apt-get install -y unzip postgresql-client gettext-base && \
+  unzip -qo lpm-0.1.2-linux.zip -d /usr/local/bin && \
+  unzip -qo liquibase-4.5.0.zip -d /opt/liquibase && \
+  ln -s  /opt/liquibase/liquibase /usr/local/bin/liquibase && \
+  rm -rf /var/lib/apt/lists/* lpm-0.1.2-linux.zip liquibase-4.5.0.zip && \
+  lpm update && lpm add -g postgresql
+
+EXPOSE 8080
+
+USER waltz
+
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+CMD [ "update",  "run" ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Learn more
 Getting started
  - [Building](docs/development/build.md) 
  - [Running](waltz-web/README.md)
+ - [Docker](docker/DOCKER.md)
 
 ---
 [![postgres build](https://github.com/finos/waltz/actions/workflows/maven.yml/badge.svg)](https://github.com/finos/waltz/actions)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+    
+services:
+  waltz:
+    image: ghcr.io/finos/waltz:latest
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:11
+    environment:
+      POSTGRES_USER: waltz
+      POSTGRES_DB: waltz
+      POSTGRES_PASSWORD: waltz

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -1,0 +1,77 @@
+
+
+# Run Waltz as a container
+
+### Pre Requisites
+
+* Docker
+* Postgres DB instance (optional, can run in Docker instead)
+
+# Configuration
+
+- The Waltz container will use default values to connect its DB.
+- By default it will try to `update` its DB and then `run` Waltz.
+- You can change this by providing environment variables to the container on the command line or as part of [docker-compose.yml](../docker-compose.yml)
+
+## Default values and actions
+The container will execute two commands: `update` and `run`. The first command will `update` the database instance by running `liquibase` against it. The second command `run` will execute `catalina.sh run` to `run` Waltz.
+
+The default parameters are listed below:
+
+* `DB_HOST="postgres"`
+* `DB_PORT="5432"`
+* `DB_NAME="waltz"`
+* `DB_USER="waltz"`
+* `DB_PASSWORD="waltz"`
+* `DB_SCHEME="waltz"`
+* `WALTZ_FROM_EMAIL="help@finos.org"`
+* `WALTZ_BASE_URL="http://127.0.0.1:8080/"`
+* `CHANGELOG_FILE=_FILE="/opt/waltz/liquibase/db.changelog-master.xml"`
+
+# Running
+
+## Docker Compose
+To start Waltz with a Postgres instance in just one command, you can use [docker-compose.yml](../docker-compose.yml) and run it with:
+
+    $> docker-compose up
+
+When the server starts you will see messages about registering
+endpoints and CORS services, similar to:
+
+````
+....
+waltz_1     | 16:33:53.088 [localhost-startStop-1] DEBUG o.f.w.w.e.a.StaticResourcesEndpoint - Registering static resources
+waltz_1     | 16:33:53.089 [localhost-startStop-1] INFO  org.finos.waltz.web.Main - Completed endpoint registration
+waltz_1     | 16:33:53.093 [localhost-startStop-1] INFO  org.finos.waltz.web.Main - GZIP not enabled
+waltz_1     | 16:33:53.094 [localhost-startStop-1] INFO  org.finos.waltz.web.Main - Enabled CORS
+waltz_1     | 09-Dec-2021 16:33:53.108 INFO [localhost-startStop-1] org.apache.catalina.startup.HostConfig.deployWAR Deployment of web application archive [/usr/local/tomcat/webapps/ROOT.war] has finished in [4,292] ms
+waltz_1     | 09-Dec-2021 16:33:53.110 INFO [main] org.apache.coyote.AbstractProtocol.start Starting ProtocolHandler ["http-nio-8080"]
+waltz_1     | 09-Dec-2021 16:33:53.117 INFO [main] org.apache.catalina.startup.Catalina.start Server startup in 4351 ms
+````
+
+Once the container is up you can access the Waltz dashboard on [http://127.0.0.1:8080/](http://127.0.0.1:8080/)
+
+## Docker run
+
+Run waltz without updating the database:
+
+    $> docker run ghcr.io/finos/waltz \
+      -p 8080:8080 \
+      -e "DB_HOST=IP_or_FQDN" \
+      -e "DB_PORT=5432" \
+      -e "DB_NAME=demo" \
+      -e "DB_USER=user" \
+      -e "DB_PASSWORD=password" \
+      run
+
+Update the database and run Waltz with fresh database:
+
+    $> docker run ghcr.io/finos/waltz \
+      -p 8080:8080 \
+      -e "DB_HOST=IP_or_FQDN" \
+      -e "DB_PORT=5432" \
+      -e "DB_NAME=demo" \
+      -e "DB_USER=user" \
+      -e "DB_PASSWORD=password" \
+      update \
+      run

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Set default values for required env vars
+export DB_HOST=${DB_HOST:-"postgres"}
+export DB_PORT=${DB_PORT:-"5432"}
+export DB_NAME=${DB_NAME:-"waltz"}
+export DB_USER=${DB_USER:-"waltz"}
+export DB_PASSWORD=${DB_PASSWORD:-"waltz"}
+export DB_SCHEME=${DB_SCHEME:-"waltz"}
+export WALTZ_FROM_EMAIL=${WALTZ_FROM_EMAIL:-"help@finos.org"}
+export WALTZ_BASE_URL=${WALTZ_BASE_URL:-"http://127.0.0.1:8080/"}
+export CHANGELOG_FILE=${CHANGELOG_FILE:-"/opt/waltz/liquibase/db.changelog-master.xml"}
+
+db_action () {
+    while [[ $(pg_isready --host="${DB_HOST}" --port="${DB_PORT}" --username="${DB_USER}" --dbname="${DB_NAME}") != *"accepting connections"* ]]
+    do
+        echo ">>> Database is not ready yet."
+        sleep 5s
+    done
+    echo ">>> Database is ready."
+
+    # changeLogFile must be relative path
+    liquibase --changeLogFile=../../../${CHANGELOG_FILE} --hub-mode=off --username="${DB_USER}" --password="${DB_PASSWORD}" --url=jdbc:postgresql://"${DB_HOST}":"${DB_PORT}"/"${DB_NAME}" "$1"
+    if [ $? -eq 0 ]; then
+        echo ">>> Database updated."
+    else
+        echo ">>> Database failed to update."
+        exit 1
+    fi
+}
+
+run_waltz () {
+    envsubst < /home/waltz/.waltz/waltz-template > /home/waltz/.waltz/waltz.properties
+    catalina.sh run
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        update) echo ">>> Update DB" && db_action update ;;
+        run) echo ">>> Run Waltz" && run_waltz ;;
+    esac
+    shift
+done

--- a/docker/waltz.properties
+++ b/docker/waltz.properties
@@ -1,0 +1,12 @@
+database.url=jdbc:postgresql://$DB_HOST:$DB_PORT/$DB_NAME 
+database.user=$DB_USER
+database.password=$DB_PASSWORD
+database.schema=$DB_SCHEME
+database.driver=org.postgresql.Driver
+
+jooq.dialect=POSTGRES
+
+database.pool.max=16
+
+waltz.from.email=$WALTZ_FROM_EMAIL
+waltz.base.url=$WALTZ_BASE_URL

--- a/waltz-web/README.md
+++ b/waltz-web/README.md
@@ -42,7 +42,7 @@ are available (typically on the classpath).
 ## Both
 
 When the server starts you will see messages about registering
-enpoints and CORS services, similar to:
+endpoints and CORS services, similar to:
 
 ````
 ....


### PR DESCRIPTION
**Building and dockerize Waltz** for running Waltz with PostgreSQL as a database so it can be run within any environment.
By default, the image will try to update DB and run Waltz with default parameters. 

In case you want to specify given actions and/or change DB parameters you can change docker's `CMD` with `run` or `update` and pass corresponding env variables as shown in the example below.

Image name: `ghcr.io/ljubon/waltz:latest`
Image size: `393MB`

Latest release: [link](https://github.com/ljubon/waltz/pkgs/container/waltz)

Default values and parameters with executing `update` and `run` 
```
docker run -it -d --name waltz ghcr.io/finos/waltz:latest
```

Working example for this PR with only `run` Waltz, without `update` DB
```
docker run -it -d --name waltz \
        --env DB_HOST=postgres \
        --env DB_PORT=5432 \
        --env DB_NAME=waltz \
        --env DB_USER=waltz \
        --env DB_PASSWORD=waltz \
        --env DB_SCHEME=waltz \
        --env WALTZ_FROM_EMAIL=mail@company.com \
        --env WALTZ_BASE_URL=http://localhost:8080 \
        ghcr.io/finos/waltz:latest run
```