### PR TITLE
Fixing app/fn decom bug

### DIFF
--- a/waltz-data/src/main/java/org/finos/waltz/data/measurable_rating_planned_decommission/MeasurableRatingPlannedDecommissionDao.java
+++ b/waltz-data/src/main/java/org/finos/waltz/data/measurable_rating_planned_decommission/MeasurableRatingPlannedDecommissionDao.java
@@ -153,17 +153,17 @@ public class MeasurableRatingPlannedDecommissionDao {
                                            String userName) {
         checkIfReadOnly(entityReference, measurableId);
 
-        MeasurableRatingPlannedDecommissionRecord existingRecord = dsl
+        Record existingRecord = dsl
                 .select(MEASURABLE_RATING_PLANNED_DECOMMISSION.fields())
                 .from(MEASURABLE_RATING_PLANNED_DECOMMISSION)
                 .where(mkRefCondition(entityReference)
                         .and(MEASURABLE_RATING_PLANNED_DECOMMISSION.MEASURABLE_ID.eq(measurableId)))
-                .fetchOne()
-                .into(MEASURABLE_RATING_PLANNED_DECOMMISSION);
+                .fetchOne();
 
         if (existingRecord != null) {
-            updateDecommDateOnRecord(existingRecord, dateChange, userName);
-            boolean updatedRecord = existingRecord.update() == 1;
+            MeasurableRatingPlannedDecommissionRecord existingDecommRecord = existingRecord.into(MEASURABLE_RATING_PLANNED_DECOMMISSION);
+            updateDecommDateOnRecord(existingDecommRecord, dateChange, userName);
+            boolean updatedRecord = existingDecommRecord.update() == 1;
             return Tuple.tuple(Operation.UPDATE, updatedRecord);
         } else {
             MeasurableRatingPlannedDecommissionRecord record = dsl.newRecord(MEASURABLE_RATING_PLANNED_DECOMMISSION);
@@ -174,7 +174,6 @@ public class MeasurableRatingPlannedDecommissionDao {
             record.setEntityKind(entityReference.kind().name());
             record.setMeasurableId(measurableId);
             boolean recordsInserted = record.insert() == 1;
-
             return Tuple.tuple(Operation.ADD, recordsInserted);
         }
     }


### PR DESCRIPTION
Code was assuming an existing record would be found and throwing an NPE if it wasn't.
This was caused by attempting to convert a null result record into a DecommRecord.

#6014