### PR TITLE
Assessment support for measurables

### DIFF
--- a/waltz-data/src/main/java/org/finos/waltz/data/assessment_definition/AssessmentDefinitionDao.java
+++ b/waltz-data/src/main/java/org/finos/waltz/data/assessment_definition/AssessmentDefinitionDao.java
@@ -19,27 +19,32 @@
 package org.finos.waltz.data.assessment_definition;
 
 
-import org.finos.waltz.schema.tables.records.AssessmentDefinitionRecord;
 import org.finos.waltz.common.StringUtilities;
 import org.finos.waltz.model.EntityKind;
+import org.finos.waltz.model.EntityReference;
 import org.finos.waltz.model.assessment_definition.AssessmentDefinition;
 import org.finos.waltz.model.assessment_definition.AssessmentVisibility;
 import org.finos.waltz.model.assessment_definition.ImmutableAssessmentDefinition;
+import org.finos.waltz.schema.tables.records.AssessmentDefinitionRecord;
+import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.RecordMapper;
+import org.jooq.impl.DSL;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.sql.Timestamp;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import static org.finos.waltz.common.StringUtilities.isEmpty;
-import static org.finos.waltz.schema.tables.AssessmentDefinition.ASSESSMENT_DEFINITION;
 import static org.finos.waltz.common.Checks.checkNotNull;
 import static org.finos.waltz.common.DateTimeUtilities.toLocalDateTime;
+import static org.finos.waltz.common.StringUtilities.isEmpty;
 import static org.finos.waltz.common.StringUtilities.mkSafe;
+import static org.finos.waltz.data.JooqUtilities.maybeReadRef;
+import static org.finos.waltz.schema.tables.AssessmentDefinition.ASSESSMENT_DEFINITION;
 
 
 @Repository
@@ -60,6 +65,10 @@ public class AssessmentDefinitionDao {
                 .isReadOnly(record.getIsReadonly())
                 .provenance(record.getProvenance())
                 .visibility(AssessmentVisibility.valueOf(record.getVisibility()))
+                .qualifierReference(maybeReadRef(
+                        record,
+                        ASSESSMENT_DEFINITION.QUALIFIER_KIND,
+                        ASSESSMENT_DEFINITION.QUALIFIER_ID))
                 .build();
     };
 
@@ -84,19 +93,21 @@ public class AssessmentDefinitionDao {
 
 
     public List<AssessmentDefinition> findAll() {
-        return dsl
-                .select(ASSESSMENT_DEFINITION.fields())
-                .from(ASSESSMENT_DEFINITION)
-                .fetch(TO_DOMAIN);
+        return findByCondition(DSL.trueCondition());
     }
 
 
     public List<AssessmentDefinition> findByEntityKind(EntityKind kind) {
-        return dsl
-                .select(ASSESSMENT_DEFINITION.fields())
-                .from(ASSESSMENT_DEFINITION)
-                .where(ASSESSMENT_DEFINITION.ENTITY_KIND.eq(kind.name()))
-                .fetch(TO_DOMAIN);
+        Condition condition = ASSESSMENT_DEFINITION.ENTITY_KIND.eq(kind.name());
+        return findByCondition(condition);
+    }
+
+
+    public Collection<AssessmentDefinition> findByEntityKindAndQualifier(EntityKind kind, EntityReference qualifier) {
+        Condition condition = ASSESSMENT_DEFINITION.ENTITY_KIND.eq(kind.name())
+                .and(ASSESSMENT_DEFINITION.QUALIFIER_KIND.eq(qualifier.kind().name()))
+                .and(ASSESSMENT_DEFINITION.QUALIFIER_ID.eq(qualifier.id()));
+        return findByCondition(condition);
     }
 
 
@@ -128,7 +139,14 @@ public class AssessmentDefinitionDao {
         r.setLastUpdatedBy(def.lastUpdatedBy());
         r.setProvenance(StringUtilities.ifEmpty(def.provenance(), "waltz"));
 
-        def.id().ifPresent(r::setId);
+        def.qualifierReference()
+           .ifPresent(qualifier -> {
+               r.setQualifierId(qualifier.id());
+               r.setQualifierKind(qualifier.kind().name());
+            });
+
+        def.id()
+           .ifPresent(r::setId);
 
         if (r.getId() == null) {
             r.insert();
@@ -141,10 +159,21 @@ public class AssessmentDefinitionDao {
 
     }
 
+
     public int remove(long definitionId) {
         return dsl
                 .deleteFrom(ASSESSMENT_DEFINITION)
                 .where(ASSESSMENT_DEFINITION.ID.eq(definitionId))
                 .execute();
     }
+
+
+    private List<AssessmentDefinition> findByCondition(Condition condition) {
+        return dsl
+                .select(ASSESSMENT_DEFINITION.fields())
+                .from(ASSESSMENT_DEFINITION)
+                .where(condition)
+                .fetch(TO_DOMAIN);
+    }
+
 }

--- a/waltz-model/src/main/java/org/finos/waltz/model/assessment_definition/AssessmentDefinition.java
+++ b/waltz-model/src/main/java/org/finos/waltz/model/assessment_definition/AssessmentDefinition.java
@@ -51,4 +51,6 @@ public abstract class AssessmentDefinition implements
     public EntityKind kind() {
         return EntityKind.ASSESSMENT_DEFINITION;
     }
+
+    public abstract Optional<EntityReference> qualifierReference();
 }

--- a/waltz-ng/client/assessments/components/section/assessment-rating-section.js
+++ b/waltz-ng/client/assessments/components/section/assessment-rating-section.js
@@ -44,8 +44,8 @@ function controller($q, serviceBroker) {
     const loadAssessments = () => {
         const definitionsPromise = serviceBroker
             .loadViewData(
-                CORE_API.AssessmentDefinitionStore.findByKind,
-                [vm.parentEntityRef.kind]);
+                CORE_API.AssessmentDefinitionStore.findByEntityReference,
+                [vm.parentEntityRef]);
 
         const ratingsPromise = serviceBroker
             .loadViewData(

--- a/waltz-ng/client/assessments/components/sub-section/assessment-rating-sub-section.html
+++ b/waltz-ng/client/assessments/components/sub-section/assessment-rating-sub-section.html
@@ -16,7 +16,7 @@
   ~
   -->
 
-<waltz-sub-section name="Overview Assessments">
+<waltz-sub-section name="Assessments">
     <content>
         <div class="waltz-sub-section-content">
             <div style="padding: 5px 0">

--- a/waltz-ng/client/assessments/components/sub-section/assessment-rating-sub-section.js
+++ b/waltz-ng/client/assessments/components/sub-section/assessment-rating-sub-section.js
@@ -39,8 +39,8 @@ function controller($q, serviceBroker) {
     const loadAll = () => {
         const definitionsPromise = serviceBroker
             .loadViewData(
-                CORE_API.AssessmentDefinitionStore.findByKind,
-                [vm.parentEntityRef.kind]);
+                CORE_API.AssessmentDefinitionStore.findByEntityReference,
+                [vm.parentEntityRef]);
 
         const ratingsPromise = serviceBroker
             .loadViewData(

--- a/waltz-ng/client/assessments/services/assessment-definition-store.js
+++ b/waltz-ng/client/assessments/services/assessment-definition-store.js
@@ -33,11 +33,16 @@ export function store($http, BaseApiUrl) {
         .get(`${BASE}/kind/${kind}`)
         .then(x => x.data);
 
+    const findByEntityReference = (ref) => $http
+        .get(`${BASE}/kind/${ref.kind}/id/${ref.id}`)
+        .then(x => x.data);
+
 
     return {
         getById,
         findAll,
-        findByKind
+        findByKind,
+        findByEntityReference
     };
 }
 
@@ -67,5 +72,10 @@ export const AssessmentDefinitionStore_API = {
         serviceFnName: 'findByKind',
         description: 'find all assessment definitions for an entity kind '
     },
+    findByEntityReference: {
+        serviceName,
+        serviceFnName: 'findByEntityReference',
+        description: 'find all assessment definitions for a parent entity ref'
+    }
 };
 

--- a/waltz-ng/client/dynamic-section/dynamic-section-definitions.js
+++ b/waltz-ng/client/dynamic-section/dynamic-section-definitions.js
@@ -570,6 +570,7 @@ const measurableSections = [
              technologySummarySection
          ]),
     bookmarksSection,
+    assessmentRatingSection,
     changeSetSection,
     entityDiagramsSection,
     entityNamedNotesSection,

--- a/waltz-ng/client/measurable/components/overview/measurable-overview.html
+++ b/waltz-ng/client/measurable/components/overview/measurable-overview.html
@@ -25,7 +25,7 @@
 
     <div ng-if="$ctrl.measurable">
         <div class="row">
-            <div class="col-sm-12">
+            <div class="col-sm-7">
                 <waltz-sub-section name="Overview">
                     <content>
                         <div style="padding:8px">
@@ -35,6 +35,11 @@
                         </div>
                     </content>
                 </waltz-sub-section>
+            </div>
+            <div class="col-sm-5">
+                <!-- Assessment Ratings -->
+                <waltz-assessment-rating-sub-section parent-entity-ref="$ctrl.measurable">
+                </waltz-assessment-rating-sub-section>
             </div>
         </div>
         <br>

--- a/waltz-ng/client/svelte-stores/assessment-definition.js
+++ b/waltz-ng/client/svelte-stores/assessment-definition.js
@@ -16,11 +16,17 @@ export function mkAssessmentDefinitionStore() {
             null,
             {force});
 
-    const save = (def) => remote
-        .execute(
-            "PUT",
-            `api/assessment-definition`,
-            def);
+    const save = (def) => {
+        const defToSave = def.entityKind === 'MEASURABLE'
+            ? def
+            : _.omit(def, ["qualifierReference"]);
+
+        return remote
+            .execute(
+                "PUT",
+                `api/assessment-definition`,
+                defToSave);
+    }
 
     const remove = (id) => remote
         .execute(

--- a/waltz-ng/client/system/svelte/assessment-definitions/AssessmentDefinitionRemovalConfirmation.svelte
+++ b/waltz-ng/client/system/svelte/assessment-definitions/AssessmentDefinitionRemovalConfirmation.svelte
@@ -2,8 +2,8 @@
     import Icon from "../../../common/svelte/Icon.svelte";
 
     import {assessmentRatingStore} from "../../../svelte-stores/assessment-rating";
+    import {selectedDefinition} from "./assessment-definition-utils";
 
-    export let definition;
     export let doCancel;
     export let doRemove;
 
@@ -11,18 +11,19 @@
     let canRemove = false;
     let removePromise = null;
 
-    $: ratingCall = assessmentRatingStore.findByDefinitionId(definition.id);
+    function onRemove() {
+        removePromise = doRemove($selectedDefinition.id);
+    }
+
+    $: ratingCall = assessmentRatingStore.findByDefinitionId($selectedDefinition.id);
     $: ratings = $ratingCall.data;
     $: canRemove = ratings.length === 0;
 
-    function onRemove() {
-        removePromise = doRemove(definition.id);
-    }
 </script>
 
 {#if $ratingCall.status === 'loading'}
     <h4 class="text-muted">
-        Analyzing impact of removing {definition.name}...
+        Analyzing impact of removing {$selectedDefinition.name}...
     </h4>
 {:else}
     <div class="removal-box"
@@ -32,8 +33,8 @@
         Are you sure you want to remove this assessment definition ?
 
         <div>
-            <h4>{definition.name}</h4>
-            <p>{definition.description}</p>
+            <h4>{$selectedDefinition.name}</h4>
+            <p>{$selectedDefinition.description}</p>
         </div>
 
         {#if ratings.length > 0}
@@ -45,7 +46,7 @@
                 Please ensure you have a backup of the data before proceeding.
                 <br>
                 You can obtain a backup from the export on the
-                <a href="../../assessment-definition/{definition.id}">overview page</a>.
+                <a href="../../assessment-definition/{$selectedDefinition.id}">overview page</a>.
                 <br>
                 <br>
                 <button class="btn btn-danger"

--- a/waltz-ng/client/system/svelte/assessment-definitions/MeasurableCategoryPicker.svelte
+++ b/waltz-ng/client/system/svelte/assessment-definitions/MeasurableCategoryPicker.svelte
@@ -1,0 +1,41 @@
+<script>
+    import _ from "lodash";
+    import {measurableCategoryStore} from "../../../svelte-stores/measurable-category-store";
+
+    const categoryCall = measurableCategoryStore.findAll();
+
+    export let disabled = false;
+    export let value = null;
+
+    let categories = [];
+
+    $: categories = _.sortBy($categoryCall?.data || [], d => d.name);
+</script>
+
+
+{#if $$slots.label}
+    <label for="categories">
+        <slot name="label"/>
+    </label>
+{/if}
+<select id="categories"
+        {disabled}
+        bind:value>
+    {#each categories as c}
+        <option value={c.id}>
+            {c.name}
+        </option>
+    {/each}
+</select>
+
+{#if $$slots.help}
+    <div class="help-block">
+        <slot name="help"/>
+    </div>
+{/if}
+
+<style>
+    label {
+        display: block;
+    }
+</style>

--- a/waltz-ng/client/system/svelte/assessment-definitions/assessment-definition-utils.js
+++ b/waltz-ng/client/system/svelte/assessment-definitions/assessment-definition-utils.js
@@ -17,23 +17,34 @@
  *
  */
 
+import {writable} from "svelte/store";
+
 export function getRequiredFields(d) {
-    return [d.name, d.entityKind, d.description];
+    const basics = [d.name, d.entityKind, d.description];
+
+    if (d.entityKind === 'MEASURABLE') {
+        return _.concat(basics, [d.qualifierReference.id]);
+    } else {
+        return basics;
+    }
 }
 
 export const possibleEntityKinds = [
     {value: "APPLICATION", name: "Application"},
     {value: "CHANGE_INITIATIVE", name: "Change Initiative"},
-    {value: "LOGICAL_DATA_FLOW", name: "Logical Data Flow"},
-    {value: "PHYSICAL_FLOW", name: "Physical Flow"},
-    {value: "PHYSICAL_SPECIFICATION", name: "Physical Specification"},
+    {value: "CHANGE_SET", name: "Change Set"},
     {value: "ENTITY_RELATIONSHIP", name: "Entity Relationship"},
     {value: "LICENCE", name: "Software Licence"},
-    {value: "SOFTWARE_PACKAGE", name: "Software Package"},
-    {value: "CHANGE_SET", name: "Change Set"},
+    {value: "LOGICAL_DATA_FLOW", name: "Logical Data Flow"},
+    {value: "MEASURABLE", name: "Measurable"},
+    {value: "PHYSICAL_FLOW", name: "Physical Flow"},
+    {value: "PHYSICAL_SPECIFICATION", name: "Physical Specification"},
+    {value: "SOFTWARE_PACKAGE", name: "Software Package"}
 ];
 
 export const possibleVisibility = [
     {value: "PRIMARY", name: "Primary"},
     {value: "SECONDARY", name: "Secondary"}
 ];
+
+export const selectedDefinition = writable(null);

--- a/waltz-service/src/main/java/org/finos/waltz/service/assessment_definition/AssessmentDefinitionService.java
+++ b/waltz-service/src/main/java/org/finos/waltz/service/assessment_definition/AssessmentDefinitionService.java
@@ -20,26 +20,35 @@ package org.finos.waltz.service.assessment_definition;
 
 
 import org.finos.waltz.data.assessment_definition.AssessmentDefinitionDao;
+import org.finos.waltz.data.measurable.MeasurableDao;
 import org.finos.waltz.model.EntityKind;
+import org.finos.waltz.model.EntityReference;
 import org.finos.waltz.model.assessment_definition.AssessmentDefinition;
+import org.finos.waltz.model.measurable.Measurable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 
 import static org.finos.waltz.common.Checks.checkNotNull;
+import static org.finos.waltz.model.EntityReference.mkRef;
 
 
 @Service
 public class AssessmentDefinitionService {
 
     private final AssessmentDefinitionDao assessmentDefinitionDao;
+    private final MeasurableDao measurableDao;
 
 
     @Autowired
-    public AssessmentDefinitionService(AssessmentDefinitionDao assessmentDefinitionDao) {
+    public AssessmentDefinitionService(AssessmentDefinitionDao assessmentDefinitionDao,
+                                       MeasurableDao measurableDao) {
         checkNotNull(assessmentDefinitionDao, "assessmentDefinitionDao cannot be null");
+        checkNotNull(measurableDao, "measurableDao cannot be null");
 
+        this.measurableDao = measurableDao;
         this.assessmentDefinitionDao = assessmentDefinitionDao;
     }
 
@@ -59,6 +68,19 @@ public class AssessmentDefinitionService {
     }
 
 
+    public Collection<AssessmentDefinition> findByEntityReference(EntityReference entityReference) {
+        switch (entityReference.kind()) {
+            case MEASURABLE:
+                Measurable m = measurableDao.getById(entityReference.id());
+                return assessmentDefinitionDao.findByEntityKindAndQualifier(
+                        entityReference.kind(),
+                        mkRef(EntityKind.MEASURABLE_CATEGORY, m.categoryId()));
+            default:
+                return findByEntityKind(entityReference.kind());
+        }
+    }
+
+
     public Long save(AssessmentDefinition def) {
         return assessmentDefinitionDao.save(def);
     }
@@ -67,4 +89,5 @@ public class AssessmentDefinitionService {
     public boolean remove(long definitionId) {
         return assessmentDefinitionDao.remove(definitionId) == 1;
     }
+
 }

--- a/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/AssessmentDefinitionEndpoint.java
+++ b/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/AssessmentDefinitionEndpoint.java
@@ -61,17 +61,20 @@ public class AssessmentDefinitionEndpoint implements Endpoint {
         String getByIdPath = WebUtilities.mkPath(BASE_URL, "id", ":id");
         String findAllPath = WebUtilities.mkPath(BASE_URL);
         String savePath = WebUtilities.mkPath(BASE_URL);
-        String findByKind = WebUtilities.mkPath(BASE_URL, "kind", ":kind");
+        String findByKindPath = WebUtilities.mkPath(BASE_URL, "kind", ":kind");
+        String findByRefPath = WebUtilities.mkPath(BASE_URL, "kind", ":kind", "id", ":id");
         String removeByIdPath = WebUtilities.mkPath(BASE_URL, "id", ":id");
 
 
         DatumRoute<AssessmentDefinition> getByIdRoute = (request, response) -> assessmentDefinitionService.getById(WebUtilities.getId(request));
         ListRoute<AssessmentDefinition> findAllRoute = (request, response) -> assessmentDefinitionService.findAll();
         ListRoute<AssessmentDefinition> findByKindRoute = (request, response) -> assessmentDefinitionService.findByEntityKind(WebUtilities.getKind(request));
+        ListRoute<AssessmentDefinition> findByRefRoute = (request, response) -> assessmentDefinitionService.findByEntityReference(WebUtilities.getEntityReference(request));
 
         EndpointUtilities.getForDatum(getByIdPath, getByIdRoute);
         EndpointUtilities.getForList(findAllPath, findAllRoute);
-        EndpointUtilities.getForList(findByKind, findByKindRoute);
+        EndpointUtilities.getForList(findByKindPath, findByKindRoute);
+        EndpointUtilities.getForList(findByRefPath, findByRefRoute);
         EndpointUtilities.putForDatum(savePath, this::saveRoute);
         EndpointUtilities.deleteForDatum(removeByIdPath, this::removeByIdRoute);
     }

--- a/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/MeasurableEndpoint.java
+++ b/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/MeasurableEndpoint.java
@@ -52,7 +52,6 @@ public class MeasurableEndpoint implements Endpoint {
         String findByMeasurableIdSelectorPath = mkPath(BASE_URL, "measurable-selector");
         String findByExternalIdPath = mkPath(BASE_URL, "external-id", ":extId");
         String findByOrgUnitIdPath = mkPath(BASE_URL, "org-unit", "id", ":id");
-        String findMeasurablesAndCountsBySelectorPath = mkPath(BASE_URL, "counts", "selector");
         String searchPath = mkPath(BASE_URL, "search", ":query");
 
         ListRoute<Measurable> findAllRoute = (request, response)


### PR DESCRIPTION
Added qualifier support to table.
Added findByEntityReference which does a lookup if passed a measurable in order to fill in the qualifier.
Resorted the list of entity kinds supported by assessments.
Added assessment section to measurable page sections.
Added assessment sub-section to measurable header.
Svelte Store will remove the qualifier if the def is not a measurable

#6127