### PR TITLE
fix failing assembly after #6346

### DIFF
--- a/waltz-data/pom.xml
+++ b/waltz-data/pom.xml
@@ -75,28 +75,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
-                <configuration>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <finalName>liquibase-scripts</finalName>
-                    <descriptors>
-                        <descriptor>${basedir}/assembly.xml</descriptor>
-                    </descriptors>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>create-archive</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/waltz-schema/assembly.xml
+++ b/waltz-schema/assembly.xml
@@ -9,7 +9,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
-            <directory>./src/main/ddl/liquibase/</directory>
+            <directory>./src/main/resources/liquibase/</directory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory>.</outputDirectory>
         </fileSet>

--- a/waltz-schema/pom.xml
+++ b/waltz-schema/pom.xml
@@ -157,6 +157,26 @@
                     </generator>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <finalName>liquibase-scripts</finalName>
+                    <descriptors>
+                        <descriptor>assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create-archive</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Signed-off-by: Hervé Boutemy <hboutemy@apache.org>

maven GH workflow is currently failing:
```
...
[INFO] ------------------------< org.finos:waltz-data >------------------------
[INFO] Building waltz-data 1.47-SNAPSHOT                                  [5/9]
[INFO] --------------------------------[ jar ]---------------------------------
...
[INFO] --- maven-assembly-plugin:3.1.1:single (create-archive) @ waltz-data ---
...
[INFO] Reading assembly descriptor: /home/runner/work/waltz/waltz/waltz-data/assembly.xml
...
Error:  Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.1.1:single (create-archive) on project waltz-data: Failed to create assembly: Error creating assembly archive zip: archive cannot be empty -> [Help 1]
...
```

It is caused by incomplete move of ddl done in https://github.com/finos/waltz/commit/531163ffc4d31f57f3af9a22c1483951b2151f3a