### PR TITLE
ImageDownloadLink throws error when called from svelte with selector …

### DIFF
--- a/waltz-ng/client/logical-flow/components/logical-flows-boingy-graph/logical-flows-boingy-graph.html
+++ b/waltz-ng/client/logical-flow/components/logical-flows-boingy-graph/logical-flows-boingy-graph.html
@@ -45,7 +45,7 @@
 
             <waltz-svelte-component styling="link"
                                     filename="flows.png"
-                                    selector=".viz"
+                                    selector="'.viz'"
                                     component="$ctrl.ImageDownloadLink">
             </waltz-svelte-component>
 


### PR DESCRIPTION
…attribute

- think angular gets confused with string literals starting with a period

#6432