### PR TITLE
Better back btn support

### DIFF
--- a/waltz-ng/client/dynamic-section/components/dynamic-section/dynamic-section.html
+++ b/waltz-ng/client/dynamic-section/components/dynamic-section/dynamic-section.html
@@ -31,7 +31,7 @@
                 <waltz-icon fixed-width="true"></waltz-icon>
             </span>
 
-            <span class="no-text-select waltz-visibility-child-30">
+            <span class="small no-text-select waltz-visibility-child-30">
                 <a ng-if="!$ctrl.embedded"
                    ui-sref="embed.internal ({kind: $ctrl.parentEntityRef.kind, id: $ctrl.parentEntityRef.id, sectionId: $ctrl.section.id })">
                     <waltz-icon name="share-square-o"
@@ -46,6 +46,15 @@
                                 flip="horizontal">
                     </waltz-icon>
                 </a>
+            </span>
+
+
+            <span class="small no-text-select waltz-visibility-child-30">
+                <button ng-click="$ctrl.onShare()"
+                        class="btn-skinny"
+                        title="Copy url to clipboard for sharing">
+                    <waltz-icon name="share-nodes"></waltz-icon>
+                </button>
             </span>
 
             <span>

--- a/waltz-ng/client/dynamic-section/components/dynamic-section/dynamic-section.js
+++ b/waltz-ng/client/dynamic-section/components/dynamic-section/dynamic-section.js
@@ -20,6 +20,8 @@ import template from "./dynamic-section.html";
 import {initialiseData} from "../../../common/index";
 import {kindToViewState} from "../../../common/link-utils";
 import {CORE_API} from "../../../common/services/core-api-utils";
+import toasts from "../../../svelte-stores/toast-store";
+
 import _ from "lodash";
 
 
@@ -62,6 +64,14 @@ function controller($state, serviceBroker) {
                     }
                 });
         }
+    };
+
+    vm.onShare = () => {
+        const url = new URL(window.location);
+        url.searchParams.set("sections", vm.section.id);
+
+        navigator.clipboard.writeText(url.toString())
+            .then(() => toasts.success("Copied shareable url to clipboard"));
     };
 
 }

--- a/waltz-ng/client/dynamic-section/section-store.js
+++ b/waltz-ng/client/dynamic-section/section-store.js
@@ -122,7 +122,7 @@ function createActiveSectionStore() {
 
     const exitPage = () => {
         const url = window.location.origin + window.location.pathname;
-        window.history.replaceState({path: url}, "", url);
+        window.history.pushState({path: url}, "", url);
     };
 
     return {
@@ -157,17 +157,9 @@ derived(
                 .map(s => s.id)
                 .value();
 
-            const paramValue = _.join(top3SectionIds, ";");
-            const newParams = Object.assign({}, parseParams(window.location.href), {sections: paramValue});
-
-            const paramsString = new URLSearchParams(newParams).toString()
-
-            const url = window.location.origin + window.location.pathname + "?" + paramsString;
-
-            window.history.replaceState({path: url}, "", url);
             window.localStorage.setItem(mkLocalStorageKey(d.pageKind), JSON.stringify(top3SectionIds));
-
             window.localStorage.setItem("active", JSON.stringify(d))
         }
     })
     .subscribe(() => {});
+

--- a/waltz-ng/client/widgets/page-header/page-header.js
+++ b/waltz-ng/client/widgets/page-header/page-header.js
@@ -40,8 +40,10 @@ function controller($document,
                     $window) {
     const vm = initialiseData(this, initialState);
 
-    vm.$onChanges = () => {
-        document.title = `Waltz: ${vm.name}`;
+    vm.$onChanges = (c) => {
+        if (c.name && document.title.name != c.name.currentValue) {
+            document.title = `Waltz: ${c.name.currentValue}`;
+        }
     };
 
     const scrollListener = () => {


### PR DESCRIPTION
We seem to have a problem with window.history.replaceState, it writes entries in the history which seem to block the back button from working correctly.

The code is in section-store and is only really needed to update the query param with a list of open sections. In turn this is only needed so the url can be sent to others and the appropriate sections will open.

After some experimentation it seems as if we can remove that feature and instead us a more straightforward sharing mechanism, where a shareable url is copied to the clip board.

#6657