### PR TITLE
Update .lgtm.yml

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,8 +1,8 @@
-extraction:
-  java:
-    index:
-      maven:
-        settings_file: .build.settings.xml
-    after_prepare:
-      # Disable modules web and job because of node dependency in web and the ad-hoc nature of jobs
-      - sed -i -e '/\s*<module>waltz-\(web\|jobs\)<\/module>/d' pom.xml
+java:
+  index:
+    maven:
+      settings_file: .build.settings.xml
+after_prepare:
+  # Disable modules web and jobs because of node dependency in web and the ad-hoc nature of jobs
+  - sed -i -e '/\s*<module>waltz-\(web\|jobs\)<\/module>/d' pom.xml
+


### PR DESCRIPTION
The code ensures that the specified Maven settings file is used for the Java project's build process. Additionally, during the "after_prepare" phase, it removes specific modules (waltz-web and waltz-jobs) from the project's pom.xml file using the sed command.

by:  https://github.com/TusharPaul01