### PR TITLE
6667:Lift the limit imposed on the settings edit input field

### DIFF
--- a/waltz-ng/client/system/svelte/settings/SettingsPanel.svelte
+++ b/waltz-ng/client/system/svelte/settings/SettingsPanel.svelte
@@ -100,7 +100,7 @@
                 {#if editing && workingSetting?.name === setting?.name}
                     <input class="form-control"
                            id="value"
-                           maxlength="255"
+                           maxlength="4000"
                            placeholder="Value for this setting"
                            bind:value={workingSetting.value}/>
                     <div style="padding-top: 1em">


### PR DESCRIPTION
#6667 Settings: edit field is too restrictive


![Waltz-6667](https://github.com/finos/waltz/assets/38087267/932f354e-30a8-4d14-84bf-eb0553833b4a)
