### PR TITLE
6048:should filter out removed users by default

### DIFF
--- a/waltz-ng/client/involvement/components/involved-people-section.html
+++ b/waltz-ng/client/involvement/components/involved-people-section.html
@@ -59,6 +59,14 @@
                     label-off="Showing all involvements (including inherited)">
                 </waltz-toggle>
             </div>
+            <div style="padding-top: 1em">
+                <waltz-toggle
+                    state="$ctrl.showRemovedPeople"
+                    on-toggle="$ctrl.onHiddenPeople()"
+                    label-on="Hide removed people"
+                    label-off="Show removed people">
+                </waltz-toggle>
+            </div>
         </div>
 
         <div ng-if="$ctrl.gridData.length > 0">

--- a/waltz-ng/client/involvement/components/involved-people-section.js
+++ b/waltz-ng/client/involvement/components/involved-people-section.js
@@ -76,7 +76,8 @@ const initialState = {
     showDirectOnly: true,
     visibility: {
         editor: false
-    }
+    },
+    showRemovedPeople: false
 };
 
 
@@ -145,7 +146,10 @@ function controller($q, displayNameService, descriptionService, serviceBroker, i
             ? vm.aggDirectInvolvements
             : vm.aggInvolvements;
 
-        vm.gridData = mkGridData(involvements, displayNameService, descriptionService);
+        const updatedGridData = mkGridData(involvements, displayNameService, descriptionService);
+        vm.gridData = vm.showRemovedPeople ?
+            updatedGridData:
+            updatedGridData.filter( d =>  d.person.isRemoved === vm.showRemovedPeople);
     }
 
     const refresh = () => {
@@ -224,6 +228,10 @@ function controller($q, displayNameService, descriptionService, serviceBroker, i
 
     vm.onToggleScope = () => {
         vm.showDirectOnly = !vm.showDirectOnly;
+        refreshGridData();
+    }
+    vm.onHiddenPeople= ()=>{
+        vm.showRemovedPeople = !vm.showRemovedPeople;
         refreshGridData();
     }
 }


### PR DESCRIPTION
#6048 
This Draft PR aims to filter out removed users by default. The added information where useful in recreating this issue.
<img width="1675" alt="Screenshot 2023-07-25 at 12 22 05 AM" src="https://github.com/finos/waltz/assets/41238234/d007d6a3-eb33-4dd3-a5c5-c5c036e0da27">
<img width="1675" alt="Screenshot 2023-07-25 at 12 22 12 AM" src="https://github.com/finos/waltz/assets/41238234/be3d91f7-1957-4473-940b-a24ca5a66f87">
