### PR TITLE
Report Grids: entity stats have view options

### DIFF
--- a/waltz-model/src/main/java/org/finos/waltz/model/report_grid/AdditionalColumnOptions.java
+++ b/waltz-model/src/main/java/org/finos/waltz/model/report_grid/AdditionalColumnOptions.java
@@ -18,7 +18,10 @@ public enum AdditionalColumnOptions {
     ROLLUP(asSet(EntityKind.DATA_TYPE)),
     COMPLETED_AND_APPROVED_ONLY(asSet(EntityKind.SURVEY_INSTANCE, EntityKind.SURVEY_QUESTION)),
     EXCLUDE_WITHDRAWN(asSet(EntityKind.SURVEY_INSTANCE, EntityKind.SURVEY_QUESTION)),
-    PRIMARY(asSet(EntityKind.MEASURABLE));
+    PRIMARY(asSet(EntityKind.MEASURABLE)),
+    VALUES_ONLY(asSet(EntityKind.ENTITY_STATISTIC)),
+    VALUES_AND_OUTCOMES(asSet(EntityKind.ENTITY_STATISTIC));
+
 
     private final Set<EntityKind> allowedKinds;
 

--- a/waltz-ng/client/report-grid/components/svelte/ReportGridFilters.svelte
+++ b/waltz-ng/client/report-grid/components/svelte/ReportGridFilters.svelte
@@ -199,12 +199,12 @@
                                 class="clickable waltz-visibility-parent"
                                 class:isActiveFilter={isActive($activeSummaries, summary)}>
                                 <td>
-                                <span class="waltz-visibility-child-30">
-                                    <Icon name={isActive($activeSummaries, summary) ? 'check' : 'arrow-left'}/>
-                                </span>
+                                    <span class="waltz-visibility-child-30">
+                                        <Icon name={isActive($activeSummaries, summary) ? 'check' : 'arrow-left'}/>
+                                    </span>
                                     <span class="column-name">
-                                {getDisplayNameForColumn(summary.column)}
-                            </span>
+                                        {getDisplayNameForColumn(summary.column)}
+                                    </span>
                                     <ul style="display: inline-block"
                                         class="list-inline column-values-summary">
                                         {#each summary.optionSummaries as option}

--- a/waltz-ng/client/report-grid/components/svelte/report-grid-utils.js
+++ b/waltz-ng/client/report-grid/components/svelte/report-grid-utils.js
@@ -63,6 +63,14 @@ export const additionalColumnOptions = {
     PRIMARY: {
         key: "PRIMARY",
         name: "Primary",
+    },
+    VALUES_ONLY: {
+        key: "VALUES_ONLY",
+        name: "Values Only",
+    },
+    VALUES_AND_OUTCOMES: {
+        key: "VALUES_AND_OUTCOMES",
+        name: "Values and Outcomes",
     }
 }
 


### PR DESCRIPTION
can now show:
- outcomes only (default)
- values only
- outcomes and values

#7037