### PR TITLE
#7460 Boingy Graph: doesn't render colours if the ratings differ from…

### DIFF
--- a/waltz-ng/client/logical-flow/services/logical-flow-utility.js
+++ b/waltz-ng/client/logical-flow/services/logical-flow-utility.js
@@ -20,8 +20,7 @@ import _ from "lodash";
 import {color} from "d3-color";
 
 
-function pickWorst(ratings = []) {
-    const sortedByBadness = [ "DISCOURAGED", "SECONDARY", "PRIMARY", "NO_OPINION" ];
+function pickWorst(ratings = [], sortedByBadness = [ "DISCOURAGED", "SECONDARY", "PRIMARY", "NO_OPINION" ]) {
     const worst = _.find(sortedByBadness, x => _.includes(ratings, x));
 
     return worst || "NO_OPINION";
@@ -37,7 +36,9 @@ export default [
                 const flowId = d.data.id;
                 const flowDecorators = decoratorsByFlowId[flowId] || [];
                 const ratings = _.map(flowDecorators, "rating");
-                return pickWorst(ratings);
+                // note: we can use the domain() because when it is retrieved, it is already sorted by position & name
+                // -> ref: flow-classification-utils.loadFlowClassificationRatings
+                return pickWorst(ratings, flowClassificationColors.domain());
             };
 
             return {


### PR DESCRIPTION
… hardcoded values (pickWorst)

- use instead the values returned from the database which can be user defined.   Fallback to original default values remains.
See below with the working result.

<img width="1801" height="1573" alt="image" src="https://github.com/user-attachments/assets/fee24712-0bb5-4556-9bfb-9a4fff67385c" />
