### PR TITLE
#7476 Reorganise and fix docker image creation

### DIFF
--- a/.github/workflows/maven-dual-build.yml
+++ b/.github/workflows/maven-dual-build.yml
@@ -95,9 +95,10 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: ghcr.io/${{ github.repository }}
-        flavor: latest=true
+        flavor: latest=false
         tags: |
-          type=ref,event=tag,enable=${{ github.ref_type == 'tag' }}
+          type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+          type=raw,value=${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
           type=raw,value=postgres-${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
           type=raw,value=postgres
 
@@ -229,7 +230,7 @@ jobs:
 
     - name: Login to GitHub Registry
       if: ${{ github.ref_type == 'tag' }}
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -238,20 +239,20 @@ jobs:
     - name: Docker meta
       if: ${{ github.ref_type == 'tag' }}
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v5
       with:
         images: ghcr.io/${{ github.repository }}
-        flavor: latest=true
+        flavor: latest=false
         tags: |
-          type=ref,event=tag,enable=${{ github.ref_type == 'tag' }}
           type=raw,value=mssql-alt-${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
           type=raw,value=mssql-alt
 
     - name: Build and push Docker image
       if: ${{ github.ref_type == 'tag' }}
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         context: .
+        file: Dockerfile.mssql
         push: ${{ github.ref_type == 'tag' }}
         labels: ${{ steps.meta.outputs.labels }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/docker-compose-mssql.yml
+++ b/docker-compose-mssql.yml
@@ -1,12 +1,14 @@
 services:
-  waltz:
-    build:
-      context: .
-      dockerfile: Dockerfile.mssql
+  waltz-mssql:
+    image: ghcr.io/finos/waltz:mssql-alt
+#    build:
+#      context: .
+#      dockerfile: Dockerfile.mssql
     ports:
       - "8080:8080"
     depends_on:
-      - sqlserver
+      sqlserver:
+        condition: service_healthy
     environment:
       DB_HOST: sqlserver
       DB_PORT: "1433"
@@ -28,6 +30,17 @@ services:
       SA_PASSWORD: "Waltz#123"
       ACCEPT_EULA: "Y"
       MSSQL_PID: "Express"
+    volumes:
+      - waltz_mssqldata:/var/opt/mssql
+    healthcheck:
+      test: /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "Waltz#123" -Q "SELECT 1" || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+volumes:
+  waltz_mssqldata:
 
 # example run commands
 # docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Waltz#123" -e "MSSQL_PID=Express"  -p 1433:1433 -d --name=sql mcr.microsoft.com/mssql/server:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,15 @@
 services:
-  waltz:
-    image: ghcr.io/finos/waltz:latest
+  waltz-postgres:
+    image: ghcr.io/finos/waltz:postgres
+    #    build:
+    #      context: .
+    #      dockerfile: Dockerfile
     ports:
       - "8080:8080"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
 
   postgres:
     image: postgres:16
@@ -14,3 +19,15 @@ services:
       POSTGRES_PASSWORD: waltz
     ports:
       - 5432:5432
+    volumes:
+      - waltz_pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: pg_isready -U waltz -d waltz
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
+volumes:
+  waltz_pgdata:


### PR DESCRIPTION
- Postgres build is latest
- fix(ci): specify Dockerfile.mssql for MSSQL build step
- The MSSQL build-push-action was missing `file: Dockerfile.mssql`, causing it to default to the Postgres Dockerfile. This resulted in the ghcr.io/finos/waltz:mssql-alt image being a Postgres build, which lacks sqlcmd, the MSSQL JDBC driver, and the MSSQL entrypoint.
- improve compose files with volumes and database ready checks