### PR TITLE
Fix StringUtilities.capitalise throwing on leading whitespace

### DIFF
--- a/waltz-common/src/main/java/org/finos/waltz/common/StringUtilities.java
+++ b/waltz-common/src/main/java/org/finos/waltz/common/StringUtilities.java
@@ -226,6 +226,9 @@ public class StringUtilities {
 
         List<String> collect = Arrays
                 .stream(words.split("\\s+"))
+                // Leading whitespace produces an empty leading token, which would
+                // otherwise blow up on charAt(0)/substring(1) below.
+                .filter(w -> !w.isEmpty())
                 .map(w -> {
                     String lower = w.toLowerCase().substring(1);
 

--- a/waltz-common/src/test/java/org/finos/waltz/common/StringUtilities_capitaliseTest.java
+++ b/waltz-common/src/test/java/org/finos/waltz/common/StringUtilities_capitaliseTest.java
@@ -44,6 +44,18 @@ public class StringUtilities_capitaliseTest {
         assertEquals("Hello World", StringUtilities.capitalise("HELLO\tWORLD"));
     }
 
+    @Test
+    public void leadingWhitespace(){
+        // Leading whitespace yields an empty leading token that must not throw
+        assertEquals("Hello", StringUtilities.capitalise(" hello"));
+        assertEquals("Hello World", StringUtilities.capitalise("  hello world"));
+    }
+
+    @Test
+    public void onlyWhitespace(){
+        assertEquals("", StringUtilities.capitalise("   "));
+    }
+
     public void newLineInputWithTab(){
         // "      " => ""
         // "Hello\tWorld" =>


### PR DESCRIPTION
## Problem

`StringUtilities.capitalise` throws `StringIndexOutOfBoundsException` when the input has leading whitespace.

`words.split("\\s+")` keeps an empty leading token when the string starts with whitespace (Java only trims *trailing* empty tokens). The per-word mapper then calls `charAt(0)` and `substring(1)` on that empty token and throws.

```java
StringUtilities.capitalise(" hello"); // throws, expected "Hello"
StringUtilities.capitalise("   ");     // throws, expected ""
```

## Fix

Filter out empty tokens before mapping:

```java
.stream(words.split("\\s+"))
.filter(w -> !w.isEmpty())
.map(...)
```

Whitespace-only input now returns `""`, which matches the intent already noted in the existing test comments (`"      " => ""`). All existing cases are unchanged, since none of them start with whitespace.

## Tests

Added `leadingWhitespace` and `onlyWhitespace` cases to `StringUtilities_capitaliseTest`. Verified the fix independently with the JDK (old throws, fixed returns `Hello` / `Hello World` / `""`, existing cases unchanged).
