### PR TITLE
Update calendar link to Zoom LFX meetings

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -506,7 +506,7 @@
                     Find working sessions and roadmap discussions in the FINOS calendar.
                 </p>
                 <div class="mt-auto pt-6">
-                    <a href="https://calendar.google.com/calendar/u/0/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig@group.calendar.google.com" target="_blank" class="inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-2.5 text-sm font-medium text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-slate-700 hover:shadow-sm hover:shadow-sky-500/10">
+                    <a href="https://zoom-lfx.platform.linuxfoundation.org/meetings/waltz?view=month" target="_blank" class="inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-2.5 text-sm font-medium text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-slate-700 hover:shadow-sm hover:shadow-sky-500/10">
                         View community calendar
                     </a>
                 </div>


### PR DESCRIPTION
The current link points to a calendar that is archived