### PR TITLE
Playwright e2e: ephemeral containerised backend + CI (#6071)

### DIFF
--- a/.github/workflows/maven-dual-build.yml
+++ b/.github/workflows/maven-dual-build.yml
@@ -63,6 +63,12 @@ jobs:
         name: waltz-web-postgres.war
         path: waltz-web/target/waltz-web-jakarta.war
 
+    - name: Publish jobs jar (for e2e sample-data seeding)
+      uses: actions/upload-artifact@v4
+      with:
+        name: waltz-jobs-uber-jar
+        path: waltz-jobs/target/uber-waltz-jobs-*.jar
+
     - name: Publish mocha results
       uses: actions/upload-artifact@v4
       with:
@@ -280,3 +286,55 @@ jobs:
           waltz-schema/target/liquibase-scripts.zip
           waltz-web/target/waltz-web-mssql-alt.war
           waltz-web/target/waltz-web-jar-with-dependencies-mssql-alt.jar
+
+
+  # End-to-end (Playwright, JS) browser tests. Reuses the war + jobs jar built by build-postgres —
+  # no Maven rebuild here. The e2e runner (waltz-e2e/scripts/e2e.mjs) spins up throwaway Postgres +
+  # Waltz app containers via Testcontainers, seeds sample data (LoadAll), runs the suite against the
+  # app's mapped port, and tears everything down. No retries — flakiness fails the build.
+  playwright-e2e:
+    needs: build-postgres
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download war (built by build-postgres)
+      uses: actions/download-artifact@v4
+      with:
+        name: waltz-web-postgres.war
+        path: waltz-web/target
+
+    - name: Download jobs jar (built by build-postgres)
+      uses: actions/download-artifact@v4
+      with:
+        name: waltz-jobs-uber-jar
+        path: waltz-jobs/target
+
+    - name: Build Waltz Docker image (from the prebuilt war)
+      run: docker build -t waltz-e2e:ci .
+
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install e2e deps + browser
+      working-directory: waltz-e2e
+      run: |
+        npm install
+        npx playwright install --with-deps chromium
+
+    - name: Run ephemeral Playwright e2e
+      working-directory: waltz-e2e
+      env:
+        E2E_WALTZ_IMAGE: waltz-e2e:ci
+      run: npm run test:e2e
+
+    - name: Upload Playwright report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: waltz-e2e/playwright-report/
+        if-no-files-found: ignore

--- a/waltz-e2e/.gitignore
+++ b/waltz-e2e/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/waltz-e2e/README.md
+++ b/waltz-e2e/README.md
@@ -1,0 +1,111 @@
+# Waltz e2e (Playwright, JS)
+
+End-to-end browser tests for Waltz. Plain JavaScript (ESM) — matching the `waltz-ng` frontend
+conventions (no TypeScript in this repo). Test data is seeded via **Waltz's REST API** (the same
+endpoints the UI uses), not via in-process Java helpers.
+
+## Running
+
+### Ephemeral (self-contained — what CI runs)
+
+Spins up throwaway Postgres + Waltz app containers via Testcontainers, seeds sample data with
+`LoadAll`, runs the suite against the app's mapped port, and tears everything down. Nothing on the
+host is assumed beyond Docker + the built artifacts.
+
+```bash
+npm install
+npx playwright install chromium
+npm run test:e2e                      # whole suite, ephemeral backend
+npm run test:e2e -- tests/bookmarks.spec.js   # one spec (args passed through)
+```
+
+Prerequisites (build artifacts): the Waltz Docker image and the jobs uber-jar.
+- Image via `E2E_WALTZ_IMAGE` (default `waltz-dev-waltz:latest`; CI builds `waltz-e2e:ci`).
+- Jobs jar auto-resolved from `../waltz-jobs/target/uber-waltz-jobs-*.jar` (build with
+  `mvn -pl waltz-jobs -am package -P waltz-postgres,dev-postgres -DskipTests`), or set `E2E_JOBS_JAR`.
+- `E2E_SKIP_LOADALL=1` skips sample-data seeding (faster for specs that self-seed).
+
+### Against an already-running instance (fast local iteration)
+
+```bash
+WALTZ_BASE_URL=http://localhost:8080 npx playwright test               # whole suite
+WALTZ_BASE_URL=http://localhost:8080 npx playwright test tests/bookmarks.spec.js
+```
+
+`WALTZ_BASE_URL` defaults to `http://localhost:8080`. Use this when you already have a populated
+Waltz running; the ephemeral runner above sets `WALTZ_BASE_URL` for you.
+
+## Report + screenshots
+
+After every run, an **HTML report with screenshots, traces and video-on-failure** is written to
+`playwright-report/`. Open it with:
+
+```bash
+npx playwright show-report
+```
+
+Config: `screenshot: "on"`, `trace: "on"` (see `playwright.config.js`).
+
+## Authoring pattern
+
+```js
+import { test, expect } from "@playwright/test";
+import { authenticate, createApp, login, apiContext, uniqueName } from "./helpers/api.js";
+
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+test("does a thing", async ({ page, context }) => {
+    const token = await login(baseURL);              // admin / password -> JWT
+    const app = await createApp(baseURL, token, uniqueName("myapp"));  // seed via API
+
+    await authenticate(context, token);              // UI reads JWT from localStorage
+    await page.goto(`/application/${app.id}`);
+    // ... drive UI, assert ...
+});
+```
+
+`helpers/api.js` provides: `login`, `apiContext` (bearer-authed APIRequestContext), `createApp`,
+`authenticate` (seeds `localStorage["satellizer_token"]`), `uniqueName`.
+
+## Rules for new specs
+
+1. **Seed via the REST API**, not the UI, for setup. Use `apiContext(baseURL, token)` and POST to the
+   relevant endpoint. Discover payloads by reading `waltz-web/.../endpoints/api/*Endpoint.java` and the
+   Java helpers in `waltz-test-common/src/main/java/org/finos/waltz/test_common/helpers/*`.
+2. **Use unique names** (`uniqueName(prefix)`) so parallel/repeat runs don't collide.
+3. **Do NOT hardcode 2023 sample-data names.** The old Java tests reference entities like "Book Data",
+   "CEO Office", "Information Classification" that no longer exist. Either seed what you need via API, or
+   query existing baseline data via API (e.g. `GET /api/involvement-kind`, `GET /api/assessment-definition`)
+   and pick one dynamically.
+4. **Locators**: prefer `getByTestId(...)` (the app uses `data-testid`). For other selectors, consult the
+   current `waltz-ng/client/**` source — section names and classes have changed since 2023 (e.g. the
+   measurable section is now "Ratings / Roadmaps", plural).
+5. The old Java tests in `waltz-test-common/src/test/java/org/finos/waltz/test_common/playwright/` are the
+   reference for **flows**, but their locators and data names are bitrotted — treat them as a guide, not gospel.
+6. **Don't edit** `helpers/api.js`, `playwright.config.js`, or other people's spec files. Put area-specific
+   helpers in your own spec file or a new `helpers/<area>.js`.
+7. If a test needs data that has **no create endpoint**, mark it `test.fixme(...)` with a comment naming the
+   gap (see below) rather than faking it.
+
+## Known API endpoints (verified)
+
+- `POST /authentication/login` `{userName, password}` → `{token}` (admin / password)
+- `POST /api/app` → create application (see `createApp`)
+- `GET  /api/app/id/:id`, `GET /api/app/search/:query`
+- `GET  /api/involvement-kind` (14 baseline kinds incl. "IT Architect")
+- `GET  /api/assessment-definition` (8 baseline defs incl. "Sensitive Data")
+- `GET  /api/org-unit/all` (baseline org units; id 10 works for `createApp`)
+- App groups: `POST /api/app-group/*` (add-owner, add-application, application-list, etc. — see `AppGroupEndpoint.java`)
+- `PUT /api/assessment-definition` create/update a definition (needs `ADMIN`/`ASSESSMENT_DEFINITION_ADMIN`; body must include `lastUpdatedBy`/`lastUpdatedAt`). Seed a `isReadOnly:false` def to allow rating — baseline defs are read-only.
+- `POST /api/user/:userName/roles` grant roles additively (union with `GET /api/user/whoami`) then re-login; needed for write ops (admin starts with only `ADMIN`).
+
+## Known seeding gaps (no create REST endpoint — confirmed)
+
+These are created direct-to-DB by the Java helpers because there's no API:
+- **Rating schemes** (no create endpoint)
+- **Persons** (feed-loaded; no create endpoint)
+- **Databases** (`DatabaseInformationEndpoint` — no create)
+
+Tests that need these as setup (e.g. report-grid's custom assessment, surveys' recipient person) can:
+- reuse a **baseline** definition/kind queried via API, or
+- be marked `test.fixme` with the gap noted, pending a seed step (LoadAll / test-only endpoint).

--- a/waltz-e2e/package.json
+++ b/waltz-e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "waltz-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "End-to-end (Playwright) browser tests for Waltz, seeding via the REST API",
+  "scripts": {
+    "test": "playwright test",
+    "test:e2e": "node scripts/e2e.mjs"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "testcontainers": "^10.13.0"
+  }
+}

--- a/waltz-e2e/playwright.config.js
+++ b/waltz-e2e/playwright.config.js
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Targets a running Waltz instance via WALTZ_BASE_URL (defaults to the local smoke stack on
+ * :8080). In the containerised model this points at the app container's mapped port.
+ */
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+export default defineConfig({
+    testDir: "./tests",
+    timeout: 45_000,
+    // Generous auto-wait: the suite drives a single, freshly-started (cold) app instance.
+    expect: { timeout: 15_000 },
+    // No retries — CI must fail on real flakiness rather than mask it. Tests must be deterministic.
+    retries: 0,
+    // Cap concurrency so the single app instance isn't overwhelmed (keeps waits honest).
+    workers: process.env.CI ? 2 : 4,
+    // Evidence written to playwright-report/ after every run:
+    //  - list : per-test pass/fail text on stdout (CI logs)
+    //  - html : self-contained report with a screenshot + trace per test
+    //  - junit: machine-readable text report (results.xml) for CI tooling
+    reporter: [
+        ["list"],
+        ["html", { open: "never", outputFolder: "playwright-report" }],
+        ["junit", { outputFile: "playwright-report/results.xml" }]
+    ],
+    use: {
+        baseURL,
+        headless: true,
+        trace: "on",
+        screenshot: "on",
+        video: "retain-on-failure"
+    },
+    projects: [
+        { name: "chromium", use: { ...devices["Desktop Chrome"] } }
+    ]
+});

--- a/waltz-e2e/scripts/e2e.mjs
+++ b/waltz-e2e/scripts/e2e.mjs
@@ -1,0 +1,309 @@
+/**
+ * Ephemeral e2e runner.
+ *
+ * Stands up a throwaway Waltz backend entirely in containers — nothing on the host is assumed
+ * beyond Docker + this repo's build artifacts — then runs the Playwright suite against it and
+ * tears everything down.
+ *
+ *   DB (container) ── Waltz app (container, liquibase + Tomcat) ── LoadAll (sample data)
+ *                                  │
+ *                     Playwright ──┘  (WALTZ_BASE_URL = app's mapped port)
+ *
+ * Config via env:
+ *   E2E_DB_TARGET     postgres | mssql            (default: postgres)
+ *   E2E_WALTZ_IMAGE   Waltz app image            (default: per-target dev image)
+ *   E2E_JOBS_JAR      path to uber jobs jar      (default: ../waltz-jobs/target/uber-waltz-jobs-*.jar)
+ *   E2E_SKIP_LOADALL  set to "1" to skip seeding (faster for specs that self-seed)
+ *
+ * NB: the app image and jobs jar must match the DB target (the MSSQL artefacts are built with the
+ * jOOQ Pro SQLSERVER dialect).
+ *
+ * Any extra args are passed through to `playwright test`, e.g.:
+ *   npm run test:e2e -- tests/bookmarks.spec.js
+ */
+import { GenericContainer, Network, Wait } from "testcontainers";
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const e2eDir = resolve(__dirname, "..");
+const repoRoot = resolve(e2eDir, "..");
+
+const APP_PORT = 8080;
+const DB_TARGET = (process.env.E2E_DB_TARGET || "postgres").toLowerCase();
+
+// Per-DB-target configuration: the DB container, how the app connects, and how LoadAll connects.
+const DB_TARGETS = {
+    postgres: {
+        defaultImage: "waltz-dev-waltz:latest",
+        db: {
+            image: "postgres:16",
+            alias: "postgres",
+            env: { POSTGRES_DB: "waltz", POSTGRES_USER: "waltz", POSTGRES_PASSWORD: "waltz" },
+            createDbCmd: null
+        },
+        appEnv: {
+            DB_HOST: "postgres", DB_PORT: "5432", DB_NAME: "waltz",
+            DB_USER: "waltz", DB_PASSWORD: "waltz", DB_SCHEME: "public"
+        },
+        loadAllProps: {
+            "database.url": "jdbc:postgresql://postgres:5432/waltz",
+            "database.user": "waltz",
+            "database.password": "waltz",
+            "database.schema": "public",
+            "database.driver": "org.postgresql.Driver",
+            "jooq.dialect": "POSTGRES"
+        }
+    },
+    mssql: {
+        defaultImage: "waltz-mssql:latest",
+        db: {
+            image: "hmxlabs/mssql-fts:2022-latest",
+            alias: "mssql",
+            env: { ACCEPT_EULA: "Y", SA_PASSWORD: "Waltz#123", MSSQL_PID: "Express" },
+            // SQL Server does not auto-create the app database; create it once it accepts connections.
+            createDbCmd: [
+                "/bin/bash", "-lc",
+                "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Waltz#123' -C " +
+                "-Q \"IF DB_ID('waltz') IS NULL CREATE DATABASE [waltz];\" || " +
+                "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'Waltz#123' " +
+                "-Q \"IF DB_ID('waltz') IS NULL CREATE DATABASE [waltz];\""
+            ]
+        },
+        appEnv: {
+            DB_HOST: "mssql", DB_PORT: "1433", DB_NAME: "waltz",
+            DB_USER: "sa", DB_PASSWORD: "Waltz#123", DB_SCHEME: "dbo"
+        },
+        loadAllProps: {
+            "database.url": "jdbc:sqlserver://mssql:1433;databaseName=waltz;encrypt=true;trustServerCertificate=true",
+            "database.user": "sa",
+            "database.password": "Waltz#123",
+            "database.schema": "dbo",
+            "database.driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+            "jooq.dialect": "SQLSERVER2014"
+        }
+    }
+};
+
+const target = DB_TARGETS[DB_TARGET];
+if (!target) {
+    console.error(`Unknown E2E_DB_TARGET '${DB_TARGET}' (expected: postgres | mssql)`);
+    process.exit(1);
+}
+
+const IMAGE = process.env.E2E_WALTZ_IMAGE || target.defaultImage;
+
+function log(msg) {
+    console.log(`\x1b[36m[e2e]\x1b[0m ${msg}`);
+}
+
+function resolveJobsJar() {
+    if (process.env.E2E_JOBS_JAR) return process.env.E2E_JOBS_JAR;
+    const targetDir = join(repoRoot, "waltz-jobs", "target");
+    const jar = existsSync(targetDir)
+        ? readdirSync(targetDir).find(f => /^uber-waltz-jobs-.*\.jar$/.test(f))
+        : undefined;
+    if (!jar) {
+        throw new Error(
+            "Could not find waltz-jobs/target/uber-waltz-jobs-*.jar. Build it first " +
+            "(e.g. `mvn -pl waltz-jobs -am package -P waltz-postgres,dev-postgres -DskipTests`) " +
+            "or set E2E_JOBS_JAR."
+        );
+    }
+    return join(targetDir, jar);
+}
+
+const loadAllProps = Object.entries(target.loadAllProps)
+    .map(([k, v]) => `${k}=${v}`)
+    .concat(["database.pool.max=8", "waltz.base.url=http://localhost:8080/"])
+    .join("\n") + "\n";
+
+// Console-only logging for LoadAll — avoids the app image's file appenders (which target a
+// ../logs dir that may not exist in the exec's working dir and spew errors).
+const loadAllLogback =
+`<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder><pattern>%d{HH:mm:ss} %-5level %logger{20} - %msg%n</pattern></encoder>
+    </appender>
+    <root level="INFO"><appender-ref ref="STDOUT"/></root>
+</configuration>
+`;
+
+// Roles the specs' write flows need. Granting them to `admin` ONCE up front (serially, before the
+// parallel suite runs) removes the lost-update race that otherwise occurs when multiple specs
+// read-modify-write the shared admin user's roles concurrently.
+const ADMIN_ROLES = [
+    "ADMIN", "ACTOR_ADMIN", "AGGREGATE_OVERLAY_DIAGRAM_EDITOR", "APP_EDITOR",
+    "ASSESSMENT_DEFINITION_ADMIN", "ATTESTATION_ADMIN", "AUTHORITATIVE_SOURCE_EDITOR",
+    "BETA_TESTER", "BULK_FLOW_EDITOR", "BULK_LEGAL_ENTITY_RELATIONSHIP_EDITOR", "BOOKMARK_EDITOR",
+    "CAPABILITY_EDITOR", "CHANGE_INITIATIVE_EDITOR", "CHANGE_SET_EDITOR", "EUDA_ADMIN",
+    "INVOLVEMENT_EDITOR", "LINEAGE_EDITOR", "LOGICAL_DATA_FLOW_EDITOR", "ORG_UNIT_EDITOR",
+    "PHYSICAL_SPECIFICATION_EDITOR", "RATING_EDITOR", "RATING_SCHEME_ADMIN", "REPORT_GRID_ADMIN",
+    "SCENARIO_ADMIN", "SCENARIO_EDITOR", "SURVEY_ADMIN", "SURVEY_TEMPLATE_ADMIN", "TAXONOMY_EDITOR",
+    "USER_ADMIN"
+];
+
+async function pollHttp(url, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        try {
+            const res = await fetch(url);
+            if (res.status === 200) return;
+        } catch {
+            // not up yet
+        }
+        await new Promise(r => setTimeout(r, 2000));
+    }
+    throw new Error(`Timed out waiting for ${url}`);
+}
+
+// SQL Server accepts TCP before it accepts logins; retry the create-database command until it works.
+async function ensureDatabase(dbContainer, cmd, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    let last;
+    while (Date.now() < deadline) {
+        const res = await dbContainer.exec(cmd);
+        if (res.exitCode === 0) return;
+        last = res.output;
+        await new Promise(r => setTimeout(r, 3000));
+    }
+    throw new Error(`Could not create database within timeout. Last output:\n${last}`);
+}
+
+// Prime the freshly-started (cold) JVM so the first real test interactions aren't pathologically
+// slow, and grant admin the full role set. Hits the heavier reference endpoints the UI pages
+// depend on; failures are ignored.
+async function warmUp(baseURL) {
+    log("warming up the backend…");
+    let token;
+    try {
+        const res = await fetch(`${baseURL}/authentication/login`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ userName: "admin", password: "password" })
+        });
+        token = (await res.json()).token;
+    } catch {
+        return; // best-effort
+    }
+
+    try {
+        log("granting admin the full role set (once, serially)…");
+        await fetch(`${baseURL}/api/user/admin/roles`, {
+            method: "POST",
+            headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+            body: JSON.stringify({ roles: ADMIN_ROLES, comment: "e2e: seed admin roles" })
+        });
+    } catch {
+        // best-effort; specs still grant their own roles as a fallback
+    }
+
+    const paths = [
+        "/api/data-types",
+        "/api/measurable-category/all",
+        "/api/measurable/all",
+        "/api/involvement-kind",
+        "/api/assessment-definition",
+        "/api/org-unit",
+        "/api/rating-scheme",
+        "/api/flow-classification",
+        "/api/app/all",
+        "/api/role"
+    ];
+    const headers = { authorization: `Bearer ${token}` };
+    for (let pass = 0; pass < 2; pass++) {
+        await Promise.all(paths.map(p => fetch(`${baseURL}${p}`, { headers }).catch(() => {})));
+    }
+}
+
+async function main() {
+    const jobsJar = resolveJobsJar();
+    log(`db target=${DB_TARGET}`);
+    log(`image=${IMAGE}`);
+    log(`jobs jar=${jobsJar}`);
+
+    const network = await new Network().start();
+    let db;
+    let app;
+    let exitCode = 1;
+
+    try {
+        log(`starting ${DB_TARGET} database…`);
+        db = await new GenericContainer(target.db.image)
+            .withNetwork(network)
+            .withNetworkAliases(target.db.alias)
+            .withEnvironment(target.db.env)
+            .withWaitStrategy(Wait.forListeningPorts())
+            .withStartupTimeout(180_000)
+            .start();
+
+        if (target.db.createDbCmd) {
+            log("creating application database…");
+            await ensureDatabase(db, target.db.createDbCmd, 180_000);
+        }
+
+        log("starting waltz app (liquibase + tomcat)…");
+        app = await new GenericContainer(IMAGE)
+            .withNetwork(network)
+            .withNetworkAliases("waltz")
+            .withEnvironment(target.appEnv)
+            .withExposedPorts(APP_PORT)
+            .withCopyFilesToContainer([{ source: jobsJar, target: "/loadall/uber-jobs.jar" }])
+            .withCopyContentToContainer([
+                { content: loadAllProps, target: "/loadall/waltz.properties" },
+                { content: loadAllLogback, target: "/loadall/logback.xml" }
+            ])
+            .withWaitStrategy(Wait.forHttp("/", APP_PORT).forStatusCode(200))
+            .withStartupTimeout(360_000)
+            .start();
+
+        if (process.env.E2E_SKIP_LOADALL === "1") {
+            log("E2E_SKIP_LOADALL=1 — skipping sample-data generation");
+        } else {
+            log("seeding sample data via LoadAll (this can take a minute)…");
+            const res = await app.exec([
+                "java",
+                "-Dlogback.configurationFile=/loadall/logback.xml",
+                "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+                "--add-opens", "java.base/java.util=ALL-UNNAMED",
+                "-cp", "/loadall:/loadall/uber-jobs.jar",
+                "org.finos.waltz.jobs.generators.LoadAll"
+            ]);
+            if (res.exitCode !== 0) {
+                console.error(res.output);
+                throw new Error(`LoadAll failed with exit code ${res.exitCode}`);
+            }
+            log("restarting app so startup caches pick up the seeded data…");
+            await app.restart();
+        }
+
+        const baseURL = `http://${app.getHost()}:${app.getMappedPort(APP_PORT)}`;
+        await pollHttp(`${baseURL}/`, 120_000);
+        log(`backend ready at ${baseURL}`);
+
+        await warmUp(baseURL);
+
+        const passthrough = process.argv.slice(2);
+        log(`running: playwright test ${passthrough.join(" ")}`.trim());
+        const run = spawnSync("npx", ["playwright", "test", ...passthrough], {
+            cwd: e2eDir,
+            stdio: "inherit",
+            env: { ...process.env, WALTZ_BASE_URL: baseURL }
+        });
+        exitCode = run.status ?? 1;
+    } finally {
+        log("tearing down containers…");
+        if (app) await app.stop().catch(() => {});
+        if (db) await db.stop().catch(() => {});
+        if (network) await network.stop().catch(() => {});
+    }
+
+    process.exit(exitCode);
+}
+
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/waltz-e2e/tests/app-search.spec.js
+++ b/waltz-e2e/tests/app-search.spec.js
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+import { authenticate, createApp, login, uniqueName } from "./helpers/api.js";
+
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+/**
+ * Seed an application purely via the REST API, then drive the UI to search for it.
+ * Mirrors the Java ApplicationSearchTest, but with API-based setup.
+ */
+test("global search finds an app created via the REST API", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const appName = uniqueName("ts_search_app");
+    await createApp(baseURL, token, appName);
+
+    await authenticate(context, token);
+    await page.goto("/");
+
+    await page.locator(".navbar-right").getByTestId("search-button").click();
+    const searchRegion = page.locator(".wnso-search-region");
+    await searchRegion.locator("input[type=search]").fill(appName);
+
+    const result = page
+        .locator(".wnso-search-results")
+        .getByTestId("entity-name")
+        .getByText(appName);
+    await expect(result).toBeVisible();
+    await result.click();
+
+    const header = page
+        .locator(".waltz-page-header")
+        .getByTestId("header-small")
+        .getByText(appName);
+    await expect(header).toBeVisible();
+});

--- a/waltz-e2e/tests/applications.spec.js
+++ b/waltz-e2e/tests/applications.spec.js
@@ -1,0 +1,144 @@
+import { test, expect } from "@playwright/test";
+import { authenticate, createApp, login, uniqueName } from "./helpers/api.js";
+
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+/**
+ * Applications area e2e (issue #6071).
+ *
+ * All setup is seeded via the REST API (createApp -> POST /api/app); the tests then
+ * drive the AngularJS/Svelte UI. The app overview is the default landing section of
+ * /application/{id}, which renders the Tags (waltz-tag-list / waltz-tag-edit) and the
+ * Aliases (Svelte AliasControl) controls, and links to the edit form (/application/{id}/edit).
+ */
+
+/**
+ * Scenario 1: Add and remove a tag on an application.
+ * Tags live in the app overview's ".waltz-tags-list" region. Editing swaps waltz-tag-list
+ * for waltz-tag-edit (ngTagsInput); adding/removing a tag auto-saves via TagStore.update.
+ */
+test("add and remove a tag on an application", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const app = await createApp(baseURL, token, uniqueName("ts_tag_app"));
+    const tagName = uniqueName("ts_tag");
+
+    await authenticate(context, token);
+    await page.goto(`/application/${app.id}`);
+
+    const tagsRegion = page.locator(".waltz-tags-list");
+    await expect(tagsRegion).toBeVisible();
+
+    // Open the tag editor ("add one." when empty, "update" otherwise).
+    // These are ng-click anchors without href, so match on their text.
+    await tagsRegion.locator("a.clickable").filter({ hasText: /add one|update/ }).first().click();
+
+    // Add a tag: type into the ngTagsInput and press Enter (auto-saves).
+    const tagInput = tagsRegion.locator("waltz-tag-edit tags-input input");
+    await tagInput.fill(tagName);
+    await tagInput.press("Enter");
+
+    // The new tag chip should appear inside the editor's tag list.
+    await expect(tagsRegion.locator(".tag-item").filter({ hasText: tagName })).toBeVisible();
+
+    // Dismiss the autocomplete dropdown (it overlays the Close button).
+    await tagInput.press("Escape");
+
+    // Close the editor and verify the tag is shown in the read-only keyword list.
+    await tagsRegion.locator("waltz-tag-edit button").filter({ hasText: "Close" }).dispatchEvent("click");
+    await expect(
+        tagsRegion.locator(".waltz-keyword-list .wkl-keyword").filter({ hasText: tagName })
+    ).toBeVisible();
+
+    // Now remove it: reopen the editor and delete the chip (auto-saves).
+    await tagsRegion.locator("a.clickable").filter({ hasText: "update" }).first().click();
+    const chip = tagsRegion.locator(".tag-item").filter({ hasText: tagName });
+    // The ngTagsInput text field overlaps the small "×" remove button, so dispatch the
+    // click directly on the element (a real click lands on the overlapping input).
+    await chip.locator(".remove-button").dispatchEvent("click");
+    await expect(chip).toHaveCount(0);
+
+    await tagInput.press("Escape");
+    await tagsRegion.locator("waltz-tag-edit button").filter({ hasText: "Close" }).dispatchEvent("click");
+
+    // Back in read-only view the tag should be gone (empty state re-appears).
+    await expect(
+        tagsRegion.locator(".waltz-keyword-list .wkl-keyword").filter({ hasText: tagName })
+    ).toHaveCount(0);
+});
+
+/**
+ * Scenario 2: Edit an application (description + business criticality) and verify it persists.
+ * Uses the Svelte edit form at /application/{id}/edit which PUTs the change set, then
+ * reloading the overview should reflect the new values.
+ */
+test("edit an application and verify the change persists", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const app = await createApp(baseURL, token, uniqueName("ts_edit_app"));
+    const newDescription = uniqueName("ts_desc");
+
+    await authenticate(context, token);
+    // Land on the view page first so the edit form's history.back() returns here on save.
+    await page.goto(`/application/${app.id}`);
+    await expect(page.locator(".waltz-page-summary").first()).toBeVisible();
+    await page.goto(`/application/${app.id}/edit`);
+
+    // Wait for the form to hydrate with the existing app data.
+    const nameInput = page.locator("#name");
+    await expect(nameInput).toHaveValue(app.name);
+
+    // Change description and business criticality (seeded as MEDIUM -> HIGH).
+    await page.locator("#description").fill(newDescription);
+    await page.locator("#criticality").selectOption("HIGH");
+
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // Saving navigates back (history.back()) to the app view. Assert the overview reflects
+    // the persisted changes.
+    await page.waitForURL(`**/application/${app.id}`);
+
+    const summary = page.locator(".waltz-page-summary").first();
+    await expect(summary.getByText(newDescription)).toBeVisible();
+    await expect(summary.getByText("High", { exact: true })).toBeVisible();
+
+    // Double-check persistence with a fresh load.
+    await page.goto(`/application/${app.id}`);
+    await expect(page.locator(".waltz-page-summary").first().getByText(newDescription)).toBeVisible();
+});
+
+/**
+ * Scenario 3: Add an alias to an application and verify it is searchable via global search.
+ * The overview's Svelte AliasControl edits aliases; ApplicationSearchDao joins ENTITY_ALIAS,
+ * so the alias term should surface the application in global search.
+ */
+test("add an alias and find the application by it in global search", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const app = await createApp(baseURL, token, uniqueName("ts_alias_app"));
+    const aliasName = uniqueName("tsalias");
+
+    await authenticate(context, token);
+    await page.goto(`/application/${app.id}`);
+
+    // Open the alias editor, add the alias, and save.
+    const aliasControl = page.locator(".waltz-alias-list");
+    await expect(aliasControl).toBeVisible();
+    await aliasControl.getByRole("button", { name: "Edit" }).click();
+
+    const aliasInput = aliasControl.locator("input");
+    await aliasInput.fill(aliasName);
+    await aliasInput.press("Enter");
+    await aliasControl.getByRole("button", { name: "Save" }).click();
+
+    // Back in view mode the alias chip should be listed.
+    await expect(aliasControl.locator("li.tag").filter({ hasText: aliasName })).toBeVisible();
+
+    // Now search globally by the alias and confirm the seeded app is found.
+    await page.locator(".navbar-right").getByTestId("search-button").click();
+    const searchRegion = page.locator(".wnso-search-region");
+    await searchRegion.locator("input[type=search]").fill(aliasName);
+
+    const result = page
+        .locator(".wnso-search-results")
+        .getByTestId("entity-name")
+        .getByText(app.name);
+    await expect(result).toBeVisible();
+});

--- a/waltz-e2e/tests/bookmarks.spec.js
+++ b/waltz-e2e/tests/bookmarks.spec.js
@@ -1,0 +1,107 @@
+import { test, expect } from "@playwright/test";
+import { authenticate, createApp, login, uniqueName } from "./helpers/api.js";
+import { bookmarksSectionPath, grantRoles, seedBookmark } from "./helpers/bookmarks.js";
+
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+/**
+ * Bookmarks e2e (issue #6071 checklist): add, edit, remove and search/filter bookmarks on an
+ * application. Setup is via the REST API; the UI is driven only for the behaviour under test.
+ *
+ * Bookmark mutation (both the REST endpoint and the UI edit/remove/add actions) requires the
+ * BOOKMARK_EDITOR role, which the sample `admin` user lacks by default — so each spec grants it.
+ * Mirrors the flow in the (bitrotted) Java BookmarkCreationAndRemovalIntegrationTest.
+ */
+
+async function openBookmarks(page, context, token, app) {
+    await authenticate(context, token);
+    await page.goto(bookmarksSectionPath(app));
+}
+
+test("adds a bookmark to an application via the UI", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await grantRoles(baseURL, token, "admin", ["ADMIN", "BOOKMARK_EDITOR"]);
+    const app = await createApp(baseURL, token, uniqueName("ts_bm_add_app"));
+
+    await openBookmarks(page, context, token, app);
+
+    // Fresh app => NoData "No bookmarks" with an "Add bookmark" button.
+    await page.getByRole("button", { name: "Add bookmark" }).first().click();
+
+    const title = uniqueName("ts_bm_title");
+    await page.locator("input#title").fill(title);
+    await page.locator("input#url").fill("http://finos.org");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page.getByRole("link", { name: title })).toBeVisible();
+});
+
+test("edits an existing bookmark", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await grantRoles(baseURL, token, "admin", ["ADMIN", "BOOKMARK_EDITOR"]);
+    const app = await createApp(baseURL, token, uniqueName("ts_bm_edit_app"));
+
+    const originalTitle = uniqueName("ts_bm_orig");
+    await seedBookmark(baseURL, token, app, { title: originalTitle });
+
+    await openBookmarks(page, context, token, app);
+
+    await expect(page.getByRole("link", { name: originalTitle })).toBeVisible();
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    const newTitle = uniqueName("ts_bm_edited");
+    const titleInput = page.locator("input#title");
+    await expect(titleInput).toHaveValue(originalTitle);
+    await titleInput.fill(newTitle);
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page.getByRole("link", { name: newTitle })).toBeVisible();
+    await expect(page.getByRole("link", { name: originalTitle })).toHaveCount(0);
+});
+
+test("removes a bookmark", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await grantRoles(baseURL, token, "admin", ["ADMIN", "BOOKMARK_EDITOR"]);
+    const app = await createApp(baseURL, token, uniqueName("ts_bm_remove_app"));
+
+    const title = uniqueName("ts_bm_doomed");
+    await seedBookmark(baseURL, token, app, { title });
+
+    await openBookmarks(page, context, token, app);
+
+    await expect(page.getByRole("link", { name: title })).toBeVisible();
+    await page.getByRole("button", { name: "Remove" }).click();
+
+    // Confirmation panel (BookmarkRemovalConfirmation) — confirm via the warning button.
+    await expect(page.getByRole("heading", { name: "Confirm bookmark removal" })).toBeVisible();
+    await page.locator("button.btn-warning").click();
+
+    await expect(page.getByRole("link", { name: title })).toHaveCount(0);
+    await expect(page.getByText("No bookmarks")).toBeVisible();
+});
+
+test("searches/filters the bookmarks list", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await grantRoles(baseURL, token, "admin", ["ADMIN", "BOOKMARK_EDITOR"]);
+    const app = await createApp(baseURL, token, uniqueName("ts_bm_search_app"));
+
+    // The search box only renders when there are more than 5 bookmarks (BookmarkPanel).
+    const marker = uniqueName("needle");
+    const targetTitle = `${marker}_target`;
+    for (const suffix of ["alpha", "bravo", "charlie", "delta", "echo"]) {
+        await seedBookmark(baseURL, token, app, { title: uniqueName(`chaff_${suffix}`) });
+    }
+    await seedBookmark(baseURL, token, app, { title: targetTitle });
+
+    await openBookmarks(page, context, token, app);
+
+    const search = page.locator("input[type=search]");
+    await expect(search).toBeVisible();
+    await expect(page.getByRole("link", { name: targetTitle })).toBeVisible();
+
+    await search.fill(marker);
+
+    await expect(page.getByRole("link", { name: targetTitle })).toBeVisible();
+    // All the chaff bookmarks should be filtered out.
+    await expect(page.locator("a", { hasText: "chaff_" })).toHaveCount(0);
+});

--- a/waltz-e2e/tests/helpers/api.js
+++ b/waltz-e2e/tests/helpers/api.js
@@ -1,0 +1,71 @@
+import { request } from "@playwright/test";
+
+/**
+ * Test data setup via Waltz's REST API — the same endpoints the UI itself uses.
+ * This is the core of the approach: no in-process Java seeding, just HTTP.
+ */
+
+const ADMIN_USER = "admin";
+const ADMIN_PASSWORD = "password";
+
+/** Authenticate and return a JWT bearer token. */
+export async function login(baseURL) {
+    const ctx = await request.newContext({ baseURL });
+    const resp = await ctx.post("/authentication/login", {
+        data: { userName: ADMIN_USER, password: ADMIN_PASSWORD }
+    });
+    if (!resp.ok()) {
+        throw new Error(`login failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body.token;
+}
+
+/** An APIRequestContext pre-loaded with the bearer token, for authenticated calls. */
+export async function apiContext(baseURL, token) {
+    return request.newContext({
+        baseURL,
+        extraHTTPHeaders: { authorization: `Bearer ${token}` }
+    });
+}
+
+/** Create an application via POST /api/app (into a baseline org unit). Returns {id, name}. */
+export async function createApp(baseURL, token, name, orgUnitId = 10) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.post("/api/app", {
+        data: {
+            name,
+            assetCode: name,
+            organisationalUnitId: orgUnitId,
+            applicationKind: "IN_HOUSE",
+            businessCriticality: "MEDIUM",
+            lifecyclePhase: "PRODUCTION",
+            overallRating: "G"
+        }
+    });
+    if (!resp.ok()) {
+        throw new Error(`create app failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return { id: body.id, name };
+}
+
+/** Waltz UI reads its JWT from localStorage["satellizer_token"] (see WaltzHttp.js). */
+export const TOKEN_STORAGE_KEY = "satellizer_token";
+
+/**
+ * Seed the browser session with the JWT so the UI is authenticated, then navigate.
+ * Usage: await authenticate(context, token); await page.goto(...).
+ */
+export async function authenticate(context, token) {
+    await context.addInitScript(
+        ([key, value]) => localStorage.setItem(key, value),
+        [TOKEN_STORAGE_KEY, token]
+    );
+}
+
+export function uniqueName(prefix) {
+    return `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+}

--- a/waltz-e2e/tests/helpers/bookmarks.js
+++ b/waltz-e2e/tests/helpers/bookmarks.js
@@ -1,0 +1,61 @@
+import { apiContext } from "./api.js";
+
+/**
+ * Bookmark-specific REST seeding helpers.
+ *
+ * The bookmark create/update/delete endpoints (and the UI edit/remove actions) are guarded by the
+ * BOOKMARK_EDITOR role. The out-of-the-box `admin` sample user only has the ADMIN role, so tests
+ * must grant BOOKMARK_EDITOR first (roles are resolved server-side per request, so no re-login is
+ * needed after granting).
+ */
+
+export const BOOKMARK_SECTION_ID = 5; // see waltz-test-common Section enum
+
+/** The embedded, single-section view for an app's bookmarks (isolates the BookmarkPanel). */
+export function bookmarksSectionPath(app) {
+    return `/embed/internal/APPLICATION/${app.id}/${BOOKMARK_SECTION_ID}`;
+}
+
+/**
+ * Additively grant roles to a user (POST /api/user/:userName/roles sets the FULL role set, so we
+ * union with the user's current roles rather than replacing them). Replacing would clobber roles
+ * granted by other specs running in parallel against the shared admin user.
+ */
+export async function grantRoles(baseURL, token, userName, roles) {
+    const ctx = await apiContext(baseURL, token);
+    const who = await (await ctx.get("/api/user/whoami")).json();
+    const merged = [...new Set([...(who.roles || []), ...roles])];
+    const resp = await ctx.post(`/api/user/${userName}/roles`, {
+        data: { roles: merged, comment: "waltz-e2e bookmark tests" }
+    });
+    if (!resp.ok()) {
+        throw new Error(`grant roles failed: ${resp.status()} ${await resp.text()}`);
+    }
+    await ctx.dispose();
+}
+
+/** Seed a bookmark against an application via POST /api/bookmarks. Returns the created bookmark. */
+export async function seedBookmark(
+    baseURL,
+    token,
+    app,
+    { title, url = "http://finos.org", bookmarkKind = "DOCUMENTATION", description } = {}
+) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.post("/api/bookmarks", {
+        data: {
+            parent: { kind: "APPLICATION", id: app.id, name: app.name },
+            bookmarkKind,
+            title,
+            url,
+            description,
+            lastUpdatedBy: "admin" // required by the model; the server overwrites it
+        }
+    });
+    if (!resp.ok()) {
+        throw new Error(`seed bookmark failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body;
+}


### PR DESCRIPTION
# Playwright e2e: ephemeral containerised backend + CI (#6071)

## Purpose
- Add a JavaScript Playwright e2e test suite in `waltz-e2e/`.
- Prove that e2e tests run as part of CI.
- Address the "automate startup of backend" item of #6071.

## How the backend works
- The runner (`waltz-e2e/scripts/e2e.mjs`) starts a throwaway backend in containers with Testcontainers.
- It starts a Postgres container and the Waltz application container.
- It seeds sample data with the `LoadAll` job.
- It runs the tests against the application's mapped port.
- It stops and removes all containers after the run.
- The host needs only Docker. The run needs no pre-started service.

## Test data
- Each test creates its data through the Waltz REST API.
- The suite does not use in-process Java helpers.

## CI
- A new `playwright-e2e` job runs in the dual build.
- The job reuses the war and the jobs jar from `build-postgres`. It does not run Maven again.
- The job publishes an HTML report (screenshots and traces) and a JUnit XML file as an artifact.
- The tests run with zero retries. A flaky test fails the build.

## Scope
- This PR is minimal on purpose.
- It includes 3 example specs: application search, bookmarks, and applications.
- Per-area coverage is tracked as sub-tasks of #6071.
- MSSQL support is a sub-task. The runner already supports MSSQL. The MSSQL path is validated locally.

## How to run locally
- `cd waltz-e2e`
- `npm install`
- `npx playwright install chromium`
- `npm run test:e2e`
