### PR TITLE
Pin maven-jar-plugin and maven-assembly-plugin versions (#7582)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -657,6 +657,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.1</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/waltz-web/pom.xml
+++ b/waltz-web/pom.xml
@@ -286,6 +286,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.7.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
## Summary
The `maven-jar-plugin` block in `pom.xml` had no pinned `<version>`, so Maven resolved the latest release at build time. A newer `maven-jar-plugin` release (`4.0.0-beta-1`) requires Maven `4.0.0-beta-3`, which the Maven 3.9.x CI runner does not meet, so the `build-postgres` job fails with `PluginIncompatibleException`.

Fixes #7582.

## Changes
- Pin `maven-jar-plugin` to `3.4.1` in `pom.xml` (requires Maven 3.6.3+).
- Audit for the same failure mode found `maven-assembly-plugin` in `waltz-web/pom.xml` unpinned; pin it to `3.7.1` (requires Maven 3.2.5+).

Both versions are Maven-3-compatible, so neither reintroduces the Maven-4 requirement.

## Verification
- `help:effective-pom` (Maven 3.9.9) resolves the pinned `3.4.1` / `3.7.1` with no `PluginIncompatibleException`.
- Full `clean package` (Maven 3.9.9, PostgreSQL) succeeds: all modules build, `jar:3.4.1` and `assembly:3.7.1` run, unit and in-memory integration tests pass (243 run, 0 failures, 0 errors), and the WAR + jar-with-dependencies artifacts are produced.