### PR TITLE
7585: Remove unused javax.mail:mail dependency (fixes FOSSA GPL-2.0-only failure)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
         <jackson.annotations.version>2.21</jackson.annotations.version>
         <jackson-jsr310.version>2.15.2</jackson-jsr310.version>
         <java.version>17</java.version>
-        <javax.mail.version>1.4.7</javax.mail.version>
         <jbcrypt.version>0.4.3</jbcrypt.version>
         <jgrapht.version>1.5.2</jgrapht.version>
         <jool.version>0.9.15</jool.version>
@@ -297,16 +296,10 @@
             </dependency>
 
 
-            <!-- mail -->
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
                 <version>${freemarker.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.mail</groupId>
-                <artifactId>mail</artifactId>
-                <version>${javax.mail.version}</version>
             </dependency>
 
 

--- a/waltz-service/pom.xml
+++ b/waltz-service/pom.xml
@@ -78,11 +78,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>de.svenkubiak</groupId>
             <artifactId>jBCrypt</artifactId>
         </dependency>


### PR DESCRIPTION
## What
Removes the unused `javax.mail:mail` dependency:
- from `waltz-service/pom.xml`
- its `<dependencyManagement>` entry and `<javax.mail.version>` property from the root `pom.xml`

## Why
The FOSSA license scan fails on `master` because `javax.mail:mail` ("JavaMail API compat") is flagged as `GPL-2.0-only`. The artifact is really dual-licensed `GPL-2.0-with-classpath-exception` + `CDDL-1.1`, but FOSSA's file scanner matches a bare `GPL-2.0-only` string in the packaged POM and flags it against the FINOS policy.

The dependency is **completely unused**:
- No `import javax.mail` / `com.sun.mail` / `jakarta.mail` in any `.java` file.
- No `JavaMailSender` / SMTP config / email templates / `service/email` package.

It was added in 2017 (`16e4c5adc`) for email notifications, which were removed in 2023 (`49fae0b92`, "removing the emailer functionality"). Email is now handled by client-side `mailto:` links. The POM entries were left behind.

## Verification
- `grep` confirms no remaining `javax.mail` references in any pom or source.
- `mvn dependency:tree -Dincludes=javax.mail:mail` should return nothing after this change.

Fixes #7585
