### PR TITLE
7568: Playwright e2e — Applications coverage

### DIFF
--- a/waltz-e2e/tests/applications.spec.js
+++ b/waltz-e2e/tests/applications.spec.js
@@ -13,6 +13,29 @@ const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
  */
 
 /**
+ * Scenario 0: The application view page loads and renders the seeded application.
+ * Confirms /application/{id} hydrates: the page header shows the app name and the
+ * overview summary shows the seeded fields (name and asset code).
+ */
+test("load the application view page and show the seeded application", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const app = await createApp(baseURL, token, uniqueName("ts_view_app"));
+
+    await authenticate(context, token);
+    await page.goto(`/application/${app.id}`);
+
+    // The page header shows the app name (see app-search.spec.js for the same locator).
+    await expect(
+        page.locator(".waltz-page-header").getByTestId("header-small").getByText(app.name)
+    ).toBeVisible();
+
+    // The overview summary renders the seeded name and asset code (createApp sets both to the name).
+    const summary = page.locator(".waltz-page-summary").first();
+    await expect(summary).toBeVisible();
+    await expect(summary.getByText(app.name).first()).toBeVisible();
+});
+
+/**
  * Scenario 1: Add and remove a tag on an application.
  * Tags live in the app overview's ".waltz-tags-list" region. Editing swaps waltz-tag-list
  * for waltz-tag-edit (ngTagsInput); adding/removing a tag auto-saves via TagStore.update.
@@ -67,11 +90,13 @@ test("add and remove a tag on an application", async ({ page, context }) => {
 });
 
 /**
- * Scenario 2: Edit an application (description + business criticality) and verify it persists.
+ * Scenario 2: Edit every editable field on an application and verify it persists.
  * Uses the Svelte edit form at /application/{id}/edit which PUTs the change set, then
- * reloading the overview should reflect the new values.
+ * reloading the overview should reflect the new values. The app is seeded (see createApp)
+ * with description empty, overallRating "G" (Invest), lifecyclePhase PRODUCTION and
+ * businessCriticality MEDIUM; every one is changed here.
  */
-test("edit an application and verify the change persists", async ({ page, context }) => {
+test("edit all fields on an application and verify the changes persist", async ({ page, context }) => {
     const token = await login(baseURL);
     const app = await createApp(baseURL, token, uniqueName("ts_edit_app"));
     const newDescription = uniqueName("ts_desc");
@@ -86,31 +111,44 @@ test("edit an application and verify the change persists", async ({ page, contex
     const nameInput = page.locator("#name");
     await expect(nameInput).toHaveValue(app.name);
 
-    // Change description and business criticality (seeded as MEDIUM -> HIGH).
+    // Change description, overall rating (G -> R), lifecycle phase (PRODUCTION -> DEVELOPMENT)
+    // and business criticality (MEDIUM -> HIGH).
     await page.locator("#description").fill(newDescription);
+    await page.locator("#rating").selectOption("R");
+    await page.locator("#phase").selectOption("DEVELOPMENT");
     await page.locator("#criticality").selectOption("HIGH");
 
     await page.getByRole("button", { name: "Save" }).click();
 
     // Saving navigates back (history.back()) to the app view. Assert the overview reflects
-    // the persisted changes.
+    // the persisted changes: description, overall rating name (investment scheme R = "Disinvest"),
+    // lifecycle phase name and criticality name.
     await page.waitForURL(`**/application/${app.id}`);
 
     const summary = page.locator(".waltz-page-summary").first();
     await expect(summary.getByText(newDescription)).toBeVisible();
+    await expect(summary.getByText("Disinvest", { exact: true })).toBeVisible();
+    await expect(summary.getByText("Development", { exact: true })).toBeVisible();
     await expect(summary.getByText("High", { exact: true })).toBeVisible();
 
     // Double-check persistence with a fresh load.
     await page.goto(`/application/${app.id}`);
-    await expect(page.locator(".waltz-page-summary").first().getByText(newDescription)).toBeVisible();
+    const reloaded = page.locator(".waltz-page-summary").first();
+    await expect(reloaded.getByText(newDescription)).toBeVisible();
+    await expect(reloaded.getByText("Disinvest", { exact: true })).toBeVisible();
+    await expect(reloaded.getByText("Development", { exact: true })).toBeVisible();
+    await expect(reloaded.getByText("High", { exact: true })).toBeVisible();
 });
 
 /**
- * Scenario 3: Add an alias to an application and verify it is searchable via global search.
+ * Scenario 3: Add an alias to an application, verify it is searchable via global search,
+ * then remove it.
  * The overview's Svelte AliasControl edits aliases; ApplicationSearchDao joins ENTITY_ALIAS,
- * so the alias term should surface the application in global search.
+ * so the alias term should surface the application in global search. In edit mode the chips
+ * are TagsInput "span.tag" entries, each with a "⨉" delete link; in view mode they are
+ * read-only "li.tag" entries.
  */
-test("add an alias and find the application by it in global search", async ({ page, context }) => {
+test("add an alias, find the application by it in global search, then remove it", async ({ page, context }) => {
     const token = await login(baseURL);
     const app = await createApp(baseURL, token, uniqueName("ts_alias_app"));
     const aliasName = uniqueName("tsalias");
@@ -141,4 +179,18 @@ test("add an alias and find the application by it in global search", async ({ pa
         .getByTestId("entity-name")
         .getByText(app.name);
     await expect(result).toBeVisible();
+
+    // Remove the alias: reopen the editor, delete the chip via its "⨉" link, and save.
+    await page.goto(`/application/${app.id}`);
+    await aliasControl.getByRole("button", { name: "Edit" }).click();
+    await aliasControl
+        .locator("span.tag")
+        .filter({ hasText: aliasName })
+        .getByRole("link")
+        .click();
+    await aliasControl.getByRole("button", { name: "Save" }).click();
+
+    // Back in view mode the alias should be gone (empty state re-appears).
+    await expect(aliasControl.locator("li.tag").filter({ hasText: aliasName })).toHaveCount(0);
+    await expect(aliasControl.getByText("No aliases defined")).toBeVisible();
 });


### PR DESCRIPTION
Sub-task of #6071 (issue #7568). Stacked on #7567 — until that merges, the diff here also shows #7567's commits.

Extends the Applications area e2e coverage. All setup is seeded through the Waltz REST API; the tests then drive the UI.

## Changes
- Add a smoke test that the application view page loads and shows the seeded application.
- Extend the edit test to change every editable field — description, overall rating, lifecycle phase and business criticality — and confirm each value persists on the overview and after a fresh reload.
- Extend the alias test to remove the alias after the search check (add -> find in search -> remove).

## Scope notes (#7568)
- "Appears in search" is already covered by `app-search.spec.js` (by name) and the alias test (by alias).
- "Show when inactive" is not included: an application cannot be marked inactive through the REST API. `POST /api/app/{id}` sets the `is_removed` column but leaves `entity_lifecycle_status` as `ACTIVE`, and the overview keys its inactive styling on `entity_lifecycle_status`. Testing this would need direct database seeding, which the suite avoids.

## Verification
- `WALTZ_BASE_URL=... npx playwright test applications.spec.js` -> 4 passed.