### PR TITLE
7588: Fix DB connection leak in cost-summary query (HikariCP pool exhaustion)

### DIFF
--- a/waltz-data/src/main/java/org/finos/waltz/data/cost/CostDao.java
+++ b/waltz-data/src/main/java/org/finos/waltz/data/cost/CostDao.java
@@ -44,7 +44,6 @@ import org.springframework.stereotype.Repository;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.finos.waltz.common.DateTimeUtilities.toLocalDateTime;
 import static org.finos.waltz.common.ListUtilities.newArrayList;
@@ -129,10 +128,8 @@ public class CostDao {
                 .orderBy(COST.AMOUNT.desc());
 
         return qry
-                .fetchStream()
-                .map(TO_COST_MAPPER::map)
                 .limit(limit)
-                .collect(Collectors.toSet());
+                .fetchSet(TO_COST_MAPPER);
     }
 
 

--- a/waltz-integration-test/src/test/java/org/finos/waltz/integration_test/inmem/dao/CostDaoTest.java
+++ b/waltz-integration-test/src/test/java/org/finos/waltz/integration_test/inmem/dao/CostDaoTest.java
@@ -1,0 +1,173 @@
+/*
+ * Waltz - Enterprise Architecture
+ * Copyright (C) 2016, 2017, 2018, 2019 Waltz open source project
+ * See README.md for more information
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific
+ *
+ */
+
+package org.finos.waltz.integration_test.inmem.dao;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+import org.finos.waltz.common.DateTimeUtilities;
+import org.finos.waltz.data.GenericSelector;
+import org.finos.waltz.data.ImmutableGenericSelector;
+import org.finos.waltz.data.cost.CostDao;
+import org.finos.waltz.integration_test.inmem.BaseInMemoryIntegrationTest;
+import org.finos.waltz.model.EntityKind;
+import org.finos.waltz.model.cost.EntityCost;
+import org.finos.waltz.schema.tables.records.CostKindRecord;
+import org.finos.waltz.schema.tables.records.CostRecord;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.finos.waltz.schema.Tables.COST;
+import static org.finos.waltz.schema.Tables.COST_KIND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class CostDaoTest extends BaseInMemoryIntegrationTest {
+
+    private static final int YEAR = 2024;
+
+    @Autowired
+    private CostDao costDao;
+
+    @Autowired
+    private DataSource dataSource;
+
+
+    @BeforeEach
+    public void wipeCosts() {
+        // COST references COST_KIND, delete children first
+        dsl.deleteFrom(COST).execute();
+        dsl.deleteFrom(COST_KIND).execute();
+    }
+
+
+    @Test
+    public void findTopCostsRespectsLimitAndOrdersByAmountDesc() {
+        long costKindId = mkCostKind();
+        // five entities with ascending amounts
+        for (int i = 1; i <= 5; i++) {
+            mkCost(costKindId, counter.incrementAndGet(), i * 10.0);   // 10, 20, 30, 40, 50
+        }
+
+        Set<EntityCost> top = costDao.findTopCostsForCostKindAndSelector(
+                costKindId, YEAR, selectorForCostKind(costKindId), 3);
+
+        assertEquals(3, top.size(), "should return exactly `limit` rows");
+
+        Set<Integer> amounts = top
+                .stream()
+                .map(c -> c.amount().intValue())
+                .collect(Collectors.toSet());
+        assertEquals(newHashSet(50, 40, 30), amounts,
+                "should return the `limit` highest amounts, ordered by amount desc");
+    }
+
+
+    /**
+     * Regression test for the HikariCP connection leak: {@code findTopCostsForCostKindAndSelector}
+     * previously used {@code fetchStream()...limit(limit)}, which abandons the lazy jOOQ cursor
+     * (and its pooled connection) whenever the result set is larger than {@code limit}. Repeatedly
+     * invoking it more times than the pool size would therefore exhaust the pool and hang.
+     *
+     * With the fix (eager {@code limit(limit).fetchSet(...)}) every connection is returned, so many
+     * iterations complete quickly and no connections remain checked out.
+     */
+    @Test
+    public void repeatedTopCostQueriesDoNotLeakConnections() {
+        long costKindId = mkCostKind();
+        // more rows than the limit, so the buggy stream would be abandoned early (and leak)
+        for (int i = 0; i < 10; i++) {
+            mkCost(costKindId, counter.incrementAndGet(), 100.0 + i);
+        }
+
+        GenericSelector selector = selectorForCostKind(costKindId);
+
+        int maxPoolSize = ((HikariDataSource) dataSource).getMaximumPoolSize();
+        int iterations = (maxPoolSize + 1) * 4;   // comfortably beyond the pool
+
+        for (int i = 0; i < iterations; i++) {
+            Set<EntityCost> top = costDao.findTopCostsForCostKindAndSelector(
+                    costKindId, YEAR, selector, 1);
+            // returning here (rather than blocking for connectionTimeout then throwing
+            // SQLTransientConnectionException) already proves connections are released
+            assertEquals(1, top.size(), "each call returns exactly `limit` rows");
+        }
+
+        HikariPoolMXBean pool = ((HikariDataSource) dataSource).getHikariPoolMXBean();
+        assertEquals(0, pool.getActiveConnections(),
+                "no db connections should remain checked out after the queries complete (leak regression)");
+        assertTrue(pool.getIdleConnections() > 0,
+                "released connections should be idle and available for reuse");
+    }
+
+
+    // --- helpers -------------------------------------------------------------
+
+    private long mkCostKind() {
+        CostKindRecord ck = dsl.newRecord(COST_KIND);
+        ck.setName("costKind" + counter.incrementAndGet());
+        ck.setExternalId("CK" + counter.incrementAndGet());
+        ck.setSubjectKind(EntityKind.APPLICATION.name());
+        ck.setIsDefault(false);
+        ck.store();
+        return ck.getId();
+    }
+
+
+    private void mkCost(long costKindId, long entityId, double amount) {
+        CostRecord c = dsl.newRecord(COST);
+        c.setCostKindId(costKindId);
+        c.setEntityId(entityId);
+        c.setEntityKind(EntityKind.APPLICATION.name());
+        c.setYear(YEAR);
+        c.setAmount(BigDecimal.valueOf(amount));
+        c.setLastUpdatedAt(DateTimeUtilities.nowUtcTimestamp());
+        c.setLastUpdatedBy("costDaoTest");
+        c.setProvenance("integration-test");
+        c.store();
+    }
+
+
+    /**
+     * Selects the entity ids that have a cost for the given cost kind, as an
+     * {@code APPLICATION} generic selector (avoids needing real APPLICATION rows).
+     */
+    private GenericSelector selectorForCostKind(long costKindId) {
+        return ImmutableGenericSelector.builder()
+                .kind(EntityKind.APPLICATION)
+                .selector(DSL
+                        .select(COST.ENTITY_ID)
+                        .from(COST)
+                        .where(COST.COST_KIND_ID.eq(costKindId)))
+                .build();
+    }
+
+
+    private static Set<Integer> newHashSet(Integer... values) {
+        return java.util.Arrays.stream(values).collect(Collectors.toSet());
+    }
+
+}

--- a/waltz-jobs/src/main/java/org/finos/waltz/jobs/clients/c1/sc1/XlsImporter.java
+++ b/waltz-jobs/src/main/java/org/finos/waltz/jobs/clients/c1/sc1/XlsImporter.java
@@ -639,9 +639,7 @@ public class XlsImporter {
     private Map<String, Long> loadOrgExtToIdMap() {
         return dsl.select(ORGANISATIONAL_UNIT.EXTERNAL_ID, ORGANISATIONAL_UNIT.ID)
                 .from(ORGANISATIONAL_UNIT)
-                .stream()
-                .collect(Collectors.toMap(r -> r.value1(), r -> r.value2()));
-
+                .fetchMap(ORGANISATIONAL_UNIT.EXTERNAL_ID, ORGANISATIONAL_UNIT.ID);
     }
 
 


### PR DESCRIPTION
## What

Fixes a database connection leak that can exhaust the HikariCP pool and take the whole application down (observed on the public demo, https://demo.waltz.finos.org/).

Closes #7588.

## Root cause

`CostDao.findTopCostsForCostKindAndSelector(...)` built its result with:

```java
return qry
        .fetchStream()
        .map(TO_COST_MAPPER::map)
        .limit(limit)
        .collect(Collectors.toSet());
```

`fetchStream()` opens a lazy jOOQ `Cursor` that holds a pooled JDBC connection until the stream is closed. jOOQ only auto-closes that cursor when the stream is **fully drained**, but `.limit(limit)` short-circuits it: when the query matches more rows than `limit`, the stream is abandoned early, the cursor is never closed, and the connection is never returned to the pool. Each such call leaks one connection; once the pool is exhausted every DB-backed request blocks for the connection timeout (30 s) and fails — including the `GET /api/oauthdetails` bootstrap call, so the SPA never renders.

Reachable via `POST /api/cost/cost-kind/{id}/target-kind/{kind}/summary/year/{year}` → `CostService.summariseByCostKindAndSelector` → this DAO method.

## Fix

```java
return qry
        .limit(limit)
        .fetchSet(TO_COST_MAPPER);
```

`fetchSet` reads eagerly and closes the cursor; `LIMIT` is pushed into SQL so the database returns only `limit` rows. This matches the sibling methods in the same DAO (`findBySelector`, `findByEntityReference`).

## Also included

- **`XlsImporter.loadOrgExtToIdMap`** used the same unclosed lazy-stream pattern (`.stream().collect(toMap(...))`); replaced with `.fetchMap(...)`. This is an offline import tool, so its blast radius is small, but the leak is real.
- **`CostDaoTest`** (integration test): asserts limit/ordering correctness, and a regression test that repeatedly queries a result set larger than `limit` and asserts the connection pool is not exhausted.

## Verification

- The regression test **fails on the pre-fix code** with the exact production error (`SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30000ms`) and **passes with the fix**.
- Manually reproduced end-to-end on a local instance: before the fix, repeated cost-summary calls drove pooled connections to the max and then every request (including unrelated endpoints) hung; after the fix, connections stay flat/returned and no requests hang.

A broader audit of `waltz-data`, `waltz-service`, `waltz-jobs` and `waltz-web` found no other instances of this lazy-cursor leak pattern beyond the two fixed here.
