### PR TITLE
7590: Add optional HikariCP connection-leak detection

### DIFF
--- a/docker/waltz.mssql.properties
+++ b/docker/waltz.mssql.properties
@@ -8,6 +8,9 @@ jooq.dialect=SQLSERVER2014
 
 database.pool.max=16
 
+# Log a stack trace if a connection is held > 60s without being returned (leak detection)
+database.pool.leak.detection.threshold.ms=60000
+
 waltz.from.email=$WALTZ_FROM_EMAIL
 waltz.base.url=$WALTZ_BASE_URL
 

--- a/docker/waltz.properties
+++ b/docker/waltz.properties
@@ -8,6 +8,9 @@ jooq.dialect=POSTGRES
 
 database.pool.max=16
 
+# Log a stack trace if a connection is held > 60s without being returned (leak detection)
+database.pool.leak.detection.threshold.ms=60000
+
 waltz.from.email=$WALTZ_FROM_EMAIL
 waltz.base.url=$WALTZ_BASE_URL
 

--- a/waltz-service/src/main/java/org/finos/waltz/service/DIBaseConfiguration.java
+++ b/waltz-service/src/main/java/org/finos/waltz/service/DIBaseConfiguration.java
@@ -68,6 +68,12 @@ public class DIBaseConfiguration {
     @Value("${database.pool.min:2}")
     private int dbPoolMin;
 
+    // 0 = disabled (HikariCP default). If > 0 (must be >= 2000), HikariCP logs a stack
+    // trace when a connection is held longer than this many ms without being returned,
+    // surfacing connection leaks instead of letting them silently exhaust the pool.
+    @Value("${database.pool.leak.detection.threshold.ms:0}")
+    private int dbPoolLeakDetectionThresholdMs;
+
     @Value("${jooq.dialect}")
     private String dialect;
 
@@ -87,6 +93,9 @@ public class DIBaseConfiguration {
         dsConfig.setDriverClassName(dbDriver);
         dsConfig.setMaximumPoolSize(dbPoolMax);
         dsConfig.setMinimumIdle(dbPoolMin);
+        if (dbPoolLeakDetectionThresholdMs > 0) {
+            dsConfig.setLeakDetectionThreshold(dbPoolLeakDetectionThresholdMs);
+        }
         return new HikariDataSource(dsConfig);
     }
 

--- a/waltz-web/src/main/resources/waltz.sample.properties
+++ b/waltz-web/src/main/resources/waltz.sample.properties
@@ -31,6 +31,7 @@ jooq.dialect=...
 # Database performance options
 database.pool.max=... # Optional, default 10: maximum number of database connections to use
 database.pool.min=... # Optional, default 2: minimum number of database connections to use
+database.pool.leak.detection.threshold.ms=... # Optional, default 0 (off): if > 0 (must be >= 2000), HikariCP logs a stack trace when a connection is held this long without being returned - use to detect connection leaks. 60000 (60s) is a good starting point; raise it if you run batch jobs that legitimately hold a connection longer, to avoid false-positive warnings
 database.performance.query.slow.threshold=... #Optional, default 10: monitor query performance, the number of seconds a query can run before being logged as a slow query in the performance monitoring log file.  Helpful in finding slow running queries        
 
 # General waltz settings


### PR DESCRIPTION
## What

Adds an optional HikariCP `leakDetectionThreshold`, wired through a new property `database.pool.leak.detection.threshold.ms`.

Closes #7590. Hardening follow-up to the connection leak fixed in #7588 / #7589.

## Why

The #7588 leak was invisible until the pool was fully drained, at which point every DB-backed request failed with `HikariPool-1 - Connection is not available, request timed out after 30000ms` and no pointer to the cause. HikariCP's leak detection logs the acquiring stack trace when a connection is held too long, turning a silent outage into an immediate diagnosis.

## Change

- `DIBaseConfiguration.dataSource()`: read `database.pool.leak.detection.threshold.ms` (default `0` = disabled, HikariCP's normal behaviour) and apply it only when `> 0`:
  ```java
  if (dbPoolLeakDetectionThresholdMs > 0) {
      dsConfig.setLeakDetectionThreshold(dbPoolLeakDetectionThresholdMs);
  }
  ```
- `waltz.sample.properties`: document the new setting.
- `docker/waltz.properties` and `docker/waltz.mssql.properties`: enable a safe default of `60000` (60 s).

## Notes

- **Backward compatible:** default `0` means no behaviour change unless a deployment opts in.
- **Diagnostic only:** it logs; it does not close, reclaim, or otherwise alter the connection lifecycle.
- **Value choice:** HikariCP requires `>= 2000`. `60000` is well above any legitimate query (Waltz's slow-query threshold defaults to 10 s) so it won't produce false positives, while still flagging a true leak within a minute. Deployments running long batch jobs can raise it via the property with no code change.
