### PR TITLE
Fix MariaDB Measurable/ServerInformation search misinterpreting '_' as a LIKE wildcard

### DIFF
--- a/waltz-data/src/main/java/org/finos/waltz/data/measurable/search/MariaMeasurableSearch.java
+++ b/waltz-data/src/main/java/org/finos/waltz/data/measurable/search/MariaMeasurableSearch.java
@@ -56,7 +56,7 @@ public class MariaMeasurableSearch implements FullTextSearch<Measurable>, Databa
         }
 
         Condition externalIdCondition = terms.stream()
-                .map(term -> MEASURABLE.EXTERNAL_ID.like("%" + term + "%"))
+                .map(term -> MEASURABLE.EXTERNAL_ID.containsIgnoreCase(term))
                 .collect(Collectors.reducing(
                         DSL.trueCondition(),
                         (acc, frag) -> acc.and(frag)));
@@ -72,7 +72,7 @@ public class MariaMeasurableSearch implements FullTextSearch<Measurable>, Databa
                 .fetch(MeasurableDao.TO_DOMAIN_MAPPER);
 
         Condition nameCondition = terms.stream()
-                .map(term -> MEASURABLE.NAME.like("%" + term + "%"))
+                .map(term -> MEASURABLE.NAME.containsIgnoreCase(term))
                 .collect(Collectors.reducing(
                         DSL.trueCondition(),
                         (acc, frag) -> acc.and(frag)));

--- a/waltz-data/src/main/java/org/finos/waltz/data/server_information/search/MariaServerInformationSearch.java
+++ b/waltz-data/src/main/java/org/finos/waltz/data/server_information/search/MariaServerInformationSearch.java
@@ -47,7 +47,7 @@ public class MariaServerInformationSearch implements FullTextSearch<ServerInform
         }
 
         Condition externalIdCondition = terms.stream()
-                .map(term -> SERVER_INFORMATION.EXTERNAL_ID.like(term + "%"))
+                .map(term -> SERVER_INFORMATION.EXTERNAL_ID.startsWithIgnoreCase(term))
                 .collect(Collectors.reducing(
                         DSL.trueCondition(),
                         (acc, frag) -> acc.and(frag)));
@@ -60,7 +60,7 @@ public class MariaServerInformationSearch implements FullTextSearch<ServerInform
                 .fetch(ServerInformationDao.TO_DOMAIN_MAPPER);
 
         Condition hostnameCondition = terms.stream()
-                .map(term -> SERVER_INFORMATION.HOSTNAME.like("%" + term + "%"))
+                .map(term -> SERVER_INFORMATION.HOSTNAME.containsIgnoreCase(term))
                 .collect(Collectors.reducing(
                         DSL.trueCondition(),
                         (acc, frag) -> acc.and(frag)));


### PR DESCRIPTION
### What

`MariaMeasurableSearch` and `MariaServerInformationSearch` build LIKE conditions via raw string concatenation (`field.like("%" + term + "%")`), using search terms straight from `SearchUtilities.mkTerms()`.

### Why this is a bug

`mkTerms()` already strips `%` defensively (along with `[`, `]`, `'`, `"`, `|`, `!`, `(`, `)`, `,`, `~`) - but not `_`, SQL's *other* `LIKE` wildcard character. So a literal underscore in a user's search query (e.g. searching for a measurable named `cost_centre`, or a server `db_prod_01`) is silently interpreted as a single-character wildcard by the database, producing incorrect, overly-broad matches instead of an exact substring/prefix match.

Not a security issue - jOOQ still parameterizes the value, so there's no SQL injection risk here. Purely a search-correctness bug, specific to terms containing an underscore.

### Fix

The three sibling MariaDB search implementations for the exact same "search by name / external id" pattern - `MariaAppSearch`, `MariaChangeInitiativeSearch`, `MariaOrganisationalUnitSearch` - already avoid this entirely by using jOOQ's `Field#containsIgnoreCase` / `Field#startsWithIgnoreCase`, which auto-escape LIKE metacharacters. This PR brings `MariaMeasurableSearch` and `MariaServerInformationSearch` in line with that existing, safe convention already used elsewhere in the codebase, rather than introducing a new one:

- `MEASURABLE.EXTERNAL_ID.like("%" + term + "%")` → `.containsIgnoreCase(term)`
- `MEASURABLE.NAME.like("%" + term + "%")` → `.containsIgnoreCase(term)`
- `SERVER_INFORMATION.EXTERNAL_ID.like(term + "%")` → `.startsWithIgnoreCase(term)` (prefix match, matching the original intent)
- `SERVER_INFORMATION.HOSTNAME.like("%" + term + "%")` → `.containsIgnoreCase(term)`

### Verification

No Docker/live MariaDB instance available in my environment, so I couldn't run the MariaDB-specific integration path end-to-end - disclosing that honestly. What I *could* verify for real:

- Full build from a clean embedded H2 database (`mvn -Pwaltz-h2 -pl waltz-data -am compile`, driving liquibase schema generation + jOOQ codegen + compile from scratch) - passes cleanly, confirming the changed code type-checks correctly against the real generated jOOQ schema.
- Checked for an existing issue describing this before opening - didn't find one (closest related, already-fixed issue is #382, a different special-character search bug).

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Small, well-scoped fix (4 lines changed across 2 files)