### PR TITLE
7573: Add create endpoints for server/database information and usage

### DIFF
--- a/waltz-data/src/main/java/org/finos/waltz/data/database_information/DatabaseInformationDao.java
+++ b/waltz-data/src/main/java/org/finos/waltz/data/database_information/DatabaseInformationDao.java
@@ -42,9 +42,11 @@ import org.jooq.lambda.tuple.Tuple2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -213,5 +215,53 @@ public class DatabaseInformationDao implements SearchDao<DatabaseInformation> {
         r.store();
 
         return r.getId();
+    }
+
+
+    /**
+     * Upserts a batch of database assets, keyed on their external id: rows with a matching
+     * external id are updated in place (preserving the id, and therefore any existing
+     * usages), everything else is inserted. Callers are expected to supply an external id
+     * for every database (see the service layer). Returns the persisted databases, re-read
+     * so the generated ids are populated.
+     */
+    public Collection<DatabaseInformation> bulkUpsert(List<DatabaseInformation> databases) {
+        dsl.transaction(ctx -> {
+            DSLContext tx = ctx.dsl();
+            databases.forEach(d -> {
+                String externalId = d.externalId().orElse(null);
+                boolean exists = externalId != null
+                        && tx.fetchExists(DATABASE_INFORMATION, DATABASE_INFORMATION.EXTERNAL_ID.eq(externalId));
+                if (exists) {
+                    tx.update(DATABASE_INFORMATION)
+                            .set(DATABASE_INFORMATION.DATABASE_NAME, d.databaseName())
+                            .set(DATABASE_INFORMATION.INSTANCE_NAME, d.instanceName())
+                            .set(DATABASE_INFORMATION.DBMS_NAME, d.dbmsName())
+                            .set(DATABASE_INFORMATION.DBMS_VENDOR, d.dbmsVendor())
+                            .set(DATABASE_INFORMATION.DBMS_VERSION, d.dbmsVersion())
+                            .set(DATABASE_INFORMATION.END_OF_LIFE_DATE, toSqlDate(d.endOfLifeDate()))
+                            .set(DATABASE_INFORMATION.LIFECYCLE_STATUS, d.lifecycleStatus().name())
+                            .set(DATABASE_INFORMATION.PROVENANCE, d.provenance())
+                            .where(DATABASE_INFORMATION.EXTERNAL_ID.eq(externalId))
+                            .execute();
+                } else {
+                    DatabaseInformationRecord record = TO_RECORD_MAPPER.apply(d);
+                    record.attach(tx.configuration());
+                    record.store();
+                }
+            });
+        });
+
+        List<String> externalIds = databases
+                .stream()
+                .map(d -> d.externalId().orElse(null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        return dsl
+                .select(DATABASE_INFORMATION.fields())
+                .from(DATABASE_INFORMATION)
+                .where(DATABASE_INFORMATION.EXTERNAL_ID.in(externalIds))
+                .fetch(DATABASE_RECORD_MAPPER);
     }
 }

--- a/waltz-data/src/main/java/org/finos/waltz/data/database_usage/DatabaseUsageDao.java
+++ b/waltz-data/src/main/java/org/finos/waltz/data/database_usage/DatabaseUsageDao.java
@@ -22,6 +22,7 @@ import org.finos.waltz.schema.tables.records.DatabaseUsageRecord;
 import org.finos.waltz.model.EntityKind;
 import org.finos.waltz.model.EntityReference;
 import org.finos.waltz.model.database_usage.DatabaseUsage;
+import org.finos.waltz.model.database_usage.DatabaseUsageCreateCommand;
 import org.finos.waltz.model.database_usage.ImmutableDatabaseUsage;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -32,15 +33,19 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.finos.waltz.schema.tables.DatabaseUsage.DATABASE_USAGE;
 import static org.finos.waltz.common.Checks.checkNotNull;
+import static org.finos.waltz.common.DateTimeUtilities.nowUtcTimestamp;
 import static org.finos.waltz.common.EnumUtilities.readEnum;
 
 
 @Repository
 public class DatabaseUsageDao {
 
+    private static final String PROVENANCE = "waltz";
     private final DSLContext dsl;
 
 
@@ -76,6 +81,46 @@ public class DatabaseUsageDao {
         return findByCondition(
                 DATABASE_USAGE.ENTITY_ID.eq(ref.id())
                         .and(DATABASE_USAGE.ENTITY_KIND.eq(ref.kind().name())));
+    }
+
+
+    /**
+     * Links the given database assets to the referenced entity in the requested environments.
+     * Replaces any existing links between the entity and the same databases (making the call
+     * idempotent), then inserts the new ones. Returns the number of links written.
+     */
+    public int create(EntityReference ref, Collection<DatabaseUsageCreateCommand> commands, String username) {
+        checkNotNull(ref, "ref cannot be null");
+        checkNotNull(commands, "commands cannot be null");
+
+        Set<Long> databaseIds = commands
+                .stream()
+                .map(DatabaseUsageCreateCommand::databaseId)
+                .collect(Collectors.toSet());
+
+        dsl.deleteFrom(DATABASE_USAGE)
+                .where(DATABASE_USAGE.ENTITY_KIND.eq(ref.kind().name()))
+                .and(DATABASE_USAGE.ENTITY_ID.eq(ref.id()))
+                .and(DATABASE_USAGE.DATABASE_ID.in(databaseIds))
+                .execute();
+
+        List<DatabaseUsageRecord> records = commands
+                .stream()
+                .map(c -> {
+                    DatabaseUsageRecord record = new DatabaseUsageRecord();
+                    record.setDatabaseId(c.databaseId());
+                    record.setEntityKind(ref.kind().name());
+                    record.setEntityId(ref.id());
+                    record.setEnvironment(c.environment());
+                    record.setProvenance(PROVENANCE);
+                    record.setLastUpdatedBy(username);
+                    record.setLastUpdatedAt(nowUtcTimestamp());
+                    return record;
+                })
+                .collect(Collectors.toList());
+
+        dsl.batchInsert(records).execute();
+        return records.size();
     }
 
     // -- helpers ---

--- a/waltz-data/src/main/java/org/finos/waltz/data/server_information/ServerInformationDao.java
+++ b/waltz-data/src/main/java/org/finos/waltz/data/server_information/ServerInformationDao.java
@@ -48,9 +48,11 @@ import org.jooq.lambda.tuple.Tuple2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -186,6 +188,66 @@ public class ServerInformationDao {
                                     s.externalId().orElse(null)))
                     .collect(Collectors.toList()))
                 .execute();
+    }
+
+
+    /**
+     * Upserts a batch of server assets, keyed on their external id: rows with a matching
+     * external id are updated in place (preserving the id, and therefore any existing
+     * usages), everything else is inserted. Callers are expected to supply an external id
+     * for every server (see the service layer). Returns the persisted servers, re-read so
+     * the generated ids are populated.
+     */
+    public Collection<ServerInformation> bulkUpsert(List<ServerInformation> servers) {
+        dsl.transaction(ctx -> {
+            DSLContext tx = ctx.dsl();
+            servers.forEach(s -> {
+                String externalId = s.externalId().orElse(null);
+                boolean exists = externalId != null
+                        && tx.fetchExists(SERVER_INFORMATION, SERVER_INFORMATION.EXTERNAL_ID.eq(externalId));
+                if (exists) {
+                    tx.update(SERVER_INFORMATION)
+                            .set(SERVER_INFORMATION.HOSTNAME, s.hostname())
+                            .set(SERVER_INFORMATION.OPERATING_SYSTEM, s.operatingSystem())
+                            .set(SERVER_INFORMATION.OPERATING_SYSTEM_VERSION, s.operatingSystemVersion())
+                            .set(SERVER_INFORMATION.COUNTRY, s.country())
+                            .set(SERVER_INFORMATION.IS_VIRTUAL, s.virtual())
+                            .set(SERVER_INFORMATION.LOCATION, s.location())
+                            .set(SERVER_INFORMATION.HW_END_OF_LIFE_DATE, toSqlDate(s.hardwareEndOfLifeDate()))
+                            .set(SERVER_INFORMATION.OS_END_OF_LIFE_DATE, toSqlDate(s.operatingSystemEndOfLifeDate()))
+                            .set(SERVER_INFORMATION.LIFECYCLE_STATUS, s.lifecycleStatus().name())
+                            .set(SERVER_INFORMATION.PROVENANCE, s.provenance())
+                            .where(SERVER_INFORMATION.EXTERNAL_ID.eq(externalId))
+                            .execute();
+                } else {
+                    tx.insertInto(SERVER_INFORMATION)
+                            .set(SERVER_INFORMATION.HOSTNAME, s.hostname())
+                            .set(SERVER_INFORMATION.OPERATING_SYSTEM, s.operatingSystem())
+                            .set(SERVER_INFORMATION.OPERATING_SYSTEM_VERSION, s.operatingSystemVersion())
+                            .set(SERVER_INFORMATION.COUNTRY, s.country())
+                            .set(SERVER_INFORMATION.IS_VIRTUAL, s.virtual())
+                            .set(SERVER_INFORMATION.LOCATION, s.location())
+                            .set(SERVER_INFORMATION.HW_END_OF_LIFE_DATE, toSqlDate(s.hardwareEndOfLifeDate()))
+                            .set(SERVER_INFORMATION.OS_END_OF_LIFE_DATE, toSqlDate(s.operatingSystemEndOfLifeDate()))
+                            .set(SERVER_INFORMATION.LIFECYCLE_STATUS, s.lifecycleStatus().name())
+                            .set(SERVER_INFORMATION.PROVENANCE, s.provenance())
+                            .set(SERVER_INFORMATION.EXTERNAL_ID, externalId)
+                            .execute();
+                }
+            });
+        });
+
+        List<String> externalIds = servers
+                .stream()
+                .map(s -> s.externalId().orElse(null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        return dsl
+                .select(SERVER_INFORMATION.fields())
+                .from(SERVER_INFORMATION)
+                .where(SERVER_INFORMATION.EXTERNAL_ID.in(externalIds))
+                .fetch(TO_DOMAIN_MAPPER);
     }
 
 

--- a/waltz-data/src/main/java/org/finos/waltz/data/server_usage/ServerUsageDao.java
+++ b/waltz-data/src/main/java/org/finos/waltz/data/server_usage/ServerUsageDao.java
@@ -22,6 +22,7 @@ import org.finos.waltz.model.EntityKind;
 import org.finos.waltz.model.EntityReference;
 import org.finos.waltz.model.server_usage.ImmutableServerUsage;
 import org.finos.waltz.model.server_usage.ServerUsage;
+import org.finos.waltz.model.server_usage.ServerUsageCreateCommand;
 import org.finos.waltz.schema.tables.records.ServerUsageRecord;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -34,7 +35,9 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.finos.waltz.common.Checks.checkNotNull;
 import static org.finos.waltz.common.DateTimeUtilities.nowUtcTimestamp;
@@ -112,6 +115,46 @@ public class ServerUsageDao {
         return findByCondition(
                 SERVER_USAGE.ENTITY_ID.eq(ref.id())
                         .and(SERVER_USAGE.ENTITY_KIND.eq(ref.kind().name())));
+    }
+
+
+    /**
+     * Links the given server assets to the referenced entity in the requested environments.
+     * Replaces any existing links between the entity and the same servers (making the call
+     * idempotent), then inserts the new ones. Returns the number of links written.
+     */
+    public int create(EntityReference ref, Collection<ServerUsageCreateCommand> commands, String username) {
+        checkNotNull(ref, "ref cannot be null");
+        checkNotNull(commands, "commands cannot be null");
+
+        Set<Long> serverIds = commands
+                .stream()
+                .map(ServerUsageCreateCommand::serverId)
+                .collect(Collectors.toSet());
+
+        dsl.deleteFrom(SERVER_USAGE)
+                .where(SERVER_USAGE.ENTITY_KIND.eq(ref.kind().name()))
+                .and(SERVER_USAGE.ENTITY_ID.eq(ref.id()))
+                .and(SERVER_USAGE.SERVER_ID.in(serverIds))
+                .execute();
+
+        List<ServerUsageRecord> records = commands
+                .stream()
+                .map(c -> {
+                    ServerUsageRecord record = new ServerUsageRecord();
+                    record.setServerId(c.serverId());
+                    record.setEntityKind(ref.kind().name());
+                    record.setEntityId(ref.id());
+                    record.setEnvironment(c.environment());
+                    record.setProvenance(PROVENANCE);
+                    record.setLastUpdatedBy(username);
+                    record.setLastUpdatedAt(nowUtcTimestamp());
+                    return record;
+                })
+                .collect(Collectors.toList());
+
+        dsl.batchInsert(records).execute();
+        return records.size();
     }
 
 

--- a/waltz-e2e/README.md
+++ b/waltz-e2e/README.md
@@ -98,13 +98,18 @@ test("does a thing", async ({ page, context }) => {
 - App groups: `POST /api/app-group/*` (add-owner, add-application, application-list, etc. — see `AppGroupEndpoint.java`)
 - `PUT /api/assessment-definition` create/update a definition (needs `ADMIN`/`ASSESSMENT_DEFINITION_ADMIN`; body must include `lastUpdatedBy`/`lastUpdatedAt`). Seed a `isReadOnly:false` def to allow rating — baseline defs are read-only.
 - `POST /api/user/:userName/roles` grant roles additively (union with `GET /api/user/whoami`) then re-login; needed for write ops (admin starts with only `ADMIN`).
+- Technology (assets + usages, all `ADMIN`-gated — see `helpers/technology.js`):
+  - `POST /api/server-info/bulk`, `POST /api/database/bulk` → upsert asset rows (keyed on `externalId`); return the saved assets with ids.
+  - `POST /api/server-usage/ref/:kind/:id`, `POST /api/database-usage/ref/:kind/:id` → link assets to an entity (e.g. `APPLICATION`); body `[{serverId|databaseId, environment}]`.
 
 ## Known seeding gaps (no create REST endpoint — confirmed)
 
 These are created direct-to-DB by the Java helpers because there's no API:
 - **Rating schemes** (no create endpoint)
 - **Persons** (feed-loaded; no create endpoint)
-- **Databases** (`DatabaseInformationEndpoint` — no create)
+
+(Servers and databases previously had no create endpoint; they are now seedable via the bulk
+asset + usage endpoints listed above.)
 
 Tests that need these as setup (e.g. report-grid's custom assessment, surveys' recipient person) can:
 - reuse a **baseline** definition/kind queried via API, or

--- a/waltz-e2e/tests/helpers/technology.js
+++ b/waltz-e2e/tests/helpers/technology.js
@@ -1,0 +1,89 @@
+import { apiContext } from "./api.js";
+
+/**
+ * Technology-area helpers (issue #7573).
+ *
+ * Servers and databases are asset-inventory entities; a "usage" ties an application (or any
+ * entity) to an asset, carrying the environment. These helpers seed both via the REST API:
+ *  - assets:  POST /api/server-info/bulk   /  POST /api/database/bulk        (upsert by externalId)
+ *  - usages:  POST /api/server-usage/ref/:kind/:id  /  POST /api/database-usage/ref/:kind/:id
+ *
+ * The write endpoints require the ADMIN role (the e2e admin user has it). Older backends
+ * without these endpoints make the seed a no-op (returns null) so the specs can skip cleanly.
+ */
+
+/** True when the response indicates the route simply is not deployed on this backend. */
+function isRouteMissing(resp) {
+    // Unknown /api routes fall through to the SPA/not-found handler (404) rather than JSON.
+    return resp.status() === 404 || resp.status() === 405;
+}
+
+async function postExpectingJson(ctx, path, data, description) {
+    const resp = await ctx.post(path, { data });
+    if (isRouteMissing(resp)) {
+        return null;
+    }
+    if (!resp.ok()) {
+        throw new Error(`${description} failed: ${resp.status()} ${await resp.text()}`);
+    }
+    return resp.json();
+}
+
+/**
+ * Seed one server and one database asset onto an application, each in its own environment.
+ * Returns {hostname, databaseName} (the searchable names of the seeded assets) or null when
+ * the write endpoints are not available on the target backend.
+ */
+export async function seedAppTechnology(baseURL, token, appId, suffix) {
+    const ctx = await apiContext(baseURL, token);
+    try {
+        const hostname = `srv_${suffix}`;
+        const databaseName = `db_${suffix}`;
+
+        // 1. Server asset + usage link.
+        const servers = [{
+            hostname,
+            externalId: `srv-${suffix}`,
+            operatingSystem: "Linux",
+            operatingSystemVersion: "5.10",
+            location: "London",
+            country: "UK",
+            lifecycleStatus: "ACTIVE"
+        }];
+        const savedServers = await postExpectingJson(ctx, "/api/server-info/bulk", servers, "server bulk save");
+        if (savedServers === null) {
+            return null;
+        }
+        const serverId = savedServers.find(s => s.hostname === hostname).id;
+        await postExpectingJson(
+            ctx,
+            `/api/server-usage/ref/APPLICATION/${appId}`,
+            [{ serverId, environment: "PROD" }],
+            "server usage link");
+
+        // 2. Database asset + usage link.
+        const databases = [{
+            databaseName,
+            instanceName: `inst_${suffix}`,
+            externalId: `db-${suffix}`,
+            dbmsVendor: "PostgreSQL",
+            dbmsName: "PostgreSQL",
+            dbmsVersion: "15",
+            lifecycleStatus: "ACTIVE"
+        }];
+        const savedDatabases = await postExpectingJson(ctx, "/api/database/bulk", databases, "database bulk save");
+        if (savedDatabases === null) {
+            return null;
+        }
+        const databaseId = savedDatabases.find(d => d.databaseName === databaseName).id;
+        await postExpectingJson(
+            ctx,
+            `/api/database-usage/ref/APPLICATION/${appId}`,
+            [{ databaseId, environment: "QA" }],
+            "database usage link");
+
+        return { hostname, databaseName };
+    } finally {
+        await ctx.dispose();
+    }
+}

--- a/waltz-e2e/tests/technology.spec.js
+++ b/waltz-e2e/tests/technology.spec.js
@@ -1,0 +1,169 @@
+import { test, expect } from "@playwright/test";
+import { authenticate, createApp, login, uniqueName } from "./helpers/api.js";
+import { seedAppTechnology } from "./helpers/technology.js";
+
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+/**
+ * Technology-area e2e (issue #7573, sub-task of #6071).
+ *
+ * Covers the checklist: show application-level technology, search for servers and
+ * databases, confirm the aggregate roll-ups, and export through the aggregate pages.
+ *
+ * Each test seeds its OWN application and technology through the REST API (asset-inventory
+ * bulk endpoints + usage-link endpoints — see helpers/technology.js), so the suite does not
+ * depend on the LoadAll sample data. On backends where those write endpoints are not
+ * deployed the seed is a no-op and the test skips.
+ *
+ * UI touch-points:
+ *  - App Technology is a dynamic section (id 18) on /application/{id}?sections=18, a
+ *    uib-tabset with Overview / Software / Servers / Databases / ... tabs, each detail
+ *    tab a ui-grid.
+ *  - The aggregate "Technologies" roll-up is a dynamic section (id 19) on any parent
+ *    entity, e.g. /org-units/{id}?sections=19, rendering waltz-sub-section pie charts and
+ *    "Export Servers" / "Export Databases" data-extract links.
+ */
+
+const ORG_UNIT_ID = 10;                       // createApp's default baseline org unit
+const TECHNOLOGY_SECTION_ID = 18;
+const TECHNOLOGY_SUMMARY_SECTION_ID = 19;
+
+/** Seed a fresh application with one server and one database; skip if endpoints are absent. */
+async function seedApp(token) {
+    const suffix = uniqueName("t").replace(/[^a-z0-9]/gi, "");
+    const app = await createApp(baseURL, token, `ts_tech_${suffix}`, ORG_UNIT_ID);
+    const seeded = await seedAppTechnology(baseURL, token, app.id, suffix);
+    return { app, seeded };
+}
+
+/** Open the global search overlay and run a query, returning the results region locator. */
+async function globalSearch(page, query) {
+    await page.locator(".navbar-right").getByTestId("search-button").click();
+    const searchRegion = page.locator(".wnso-search-region");
+    await searchRegion.locator("input[type=search]").fill(query);
+    return page.locator(".wnso-search-results");
+}
+
+
+test("application technology section lists servers and databases", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const { app, seeded } = await seedApp(token);
+
+    test.skip(!seeded, "technology write endpoints not available on this backend");
+
+    await authenticate(context, token);
+    await page.goto(`/application/${app.id}?sections=${TECHNOLOGY_SECTION_ID}`);
+
+    // The Technology section renders its uib-tabset (tabs are anchor "links"); the
+    // Servers/Databases tabs only exist inside this section.
+    const tabs = page.locator(".nav-tabs");
+    const serversTab = tabs.getByRole("link", { name: "Servers", exact: true });
+    await expect(serversTab).toBeVisible();
+
+    // Servers tab: the detail grid (ng-if="showServerDetail") renders the seeded server.
+    await serversTab.click();
+    await expect(page.locator(".ui-grid-cell-contents").filter({ hasText: seeded.hostname }).first()).toBeVisible();
+
+    // Databases tab: renders the seeded database.
+    await tabs.getByRole("link", { name: "Databases", exact: true }).click();
+    await expect(page.locator(".ui-grid-cell-contents").filter({ hasText: seeded.databaseName }).first()).toBeVisible();
+});
+
+
+test("global search finds an existing server and opens its landing page", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const { seeded } = await seedApp(token);
+
+    test.skip(!seeded, "technology write endpoints not available on this backend");
+
+    const hostname = seeded.hostname;
+
+    await authenticate(context, token);
+    await page.goto("/");
+
+    // Search by the seeded hostname; the SERVER search result's name IS the hostname.
+    const results = await globalSearch(page, hostname);
+    const result = results.getByTestId("entity-name").getByText(hostname, { exact: true });
+    await expect(result.first()).toBeVisible();
+    await result.first().click();
+
+    // Landing page is the server view; its page header renders the hostname.
+    const header = page
+        .locator(".waltz-page-header")
+        .getByTestId("header-name-truncated")
+        .getByText(hostname, { exact: true });
+    await expect(header.first()).toBeVisible();
+});
+
+
+test("global search finds an existing database and opens its landing page", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const { seeded } = await seedApp(token);
+
+    test.skip(!seeded, "technology write endpoints not available on this backend");
+
+    const databaseName = seeded.databaseName;
+
+    await authenticate(context, token);
+    await page.goto("/");
+
+    // Search by the seeded database name; the DATABASE search result's name IS that name.
+    const results = await globalSearch(page, databaseName);
+    const result = results.getByTestId("entity-name").getByText(databaseName, { exact: true });
+    await expect(result.first()).toBeVisible();
+    await result.first().click();
+
+    // Landing page is the database view; its page header renders the database name.
+    const header = page
+        .locator(".waltz-page-header")
+        .getByTestId("header-name-truncated")
+        .getByText(databaseName, { exact: true });
+    await expect(header.first()).toBeVisible();
+});
+
+
+test("aggregate technology roll-up shows server and database summaries", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const { seeded } = await seedApp(token);
+
+    test.skip(!seeded, "technology write endpoints not available on this backend");
+
+    await authenticate(context, token);
+    // The roll-up aggregates over the org unit's applications; the seeded app sits in ORG_UNIT_ID.
+    await page.goto(`/org-units/${ORG_UNIT_ID}?sections=${TECHNOLOGY_SUMMARY_SECTION_ID}`);
+
+    // Servers and Databases sub-sections roll up their pie charts (e.g. "By Operating System").
+    await expect(page.locator("waltz-sub-section").filter({ hasText: "Servers" }).first()).toBeVisible();
+    await expect(page.locator("waltz-sub-section").filter({ hasText: "Databases" }).first()).toBeVisible();
+    await expect(page.getByText("By Operating System", { exact: true }).first()).toBeVisible();
+});
+
+
+test("export servers as CSV from the aggregate technology page", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const { seeded } = await seedApp(token);
+
+    test.skip(!seeded, "technology write endpoints not available on this backend");
+
+    await authenticate(context, token);
+    await page.goto(`/org-units/${ORG_UNIT_ID}?sections=${TECHNOLOGY_SUMMARY_SECTION_ID}`);
+
+    // The "Export Servers" data-extract link is a dropdown (cloud-download toggle + caret).
+    const exportToggle = page.locator(".waltz-sub-section-controls a").filter({ hasText: "Export Servers" });
+    await expect(exportToggle.first()).toBeVisible();
+    await exportToggle.first().click();
+
+    // Choose "Export as csv" (each export link has its own body-appended menu, so target the
+    // open/visible one) and confirm a download is produced with the server EOL columns.
+    const downloadPromise = page.waitForEvent("download");
+    await page
+        .locator(".dropdown-menu a.clickable")
+        .filter({ hasText: "Export as csv", visible: true })
+        .click();
+    const download = await downloadPromise;
+
+    const path = await download.path();
+    const fs = await import("node:fs/promises");
+    const contents = await fs.readFile(path, "utf8");
+    expect(contents).toContain("Host Name");
+});

--- a/waltz-model/src/main/java/org/finos/waltz/model/database_usage/DatabaseUsageCreateCommand.java
+++ b/waltz-model/src/main/java/org/finos/waltz/model/database_usage/DatabaseUsageCreateCommand.java
@@ -1,0 +1,43 @@
+/*
+ * Waltz - Enterprise Architecture
+ * Copyright (C) 2016, 2017, 2018, 2019 Waltz open source project
+ * See README.md for more information
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific
+ *
+ */
+
+package org.finos.waltz.model.database_usage;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.finos.waltz.model.command.Command;
+import org.immutables.value.Value;
+
+
+/**
+ * Describes a request to link an existing database asset to an entity (e.g. an application).
+ * The target entity is supplied out of band (typically via the request path); only the
+ * database and the environment it is used in are carried here.
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableDatabaseUsageCreateCommand.class)
+@JsonDeserialize(as = ImmutableDatabaseUsageCreateCommand.class)
+public abstract class DatabaseUsageCreateCommand implements Command {
+
+    public abstract long databaseId();
+
+    @Value.Default
+    public String environment() {
+        return "PROD";
+    }
+}

--- a/waltz-model/src/main/java/org/finos/waltz/model/server_usage/ServerUsageCreateCommand.java
+++ b/waltz-model/src/main/java/org/finos/waltz/model/server_usage/ServerUsageCreateCommand.java
@@ -1,0 +1,43 @@
+/*
+ * Waltz - Enterprise Architecture
+ * Copyright (C) 2016, 2017, 2018, 2019 Waltz open source project
+ * See README.md for more information
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific
+ *
+ */
+
+package org.finos.waltz.model.server_usage;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.finos.waltz.model.command.Command;
+import org.immutables.value.Value;
+
+
+/**
+ * Describes a request to link an existing server asset to an entity (e.g. an application).
+ * The target entity is supplied out of band (typically via the request path); only the
+ * server and the environment it is used in are carried here.
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableServerUsageCreateCommand.class)
+@JsonDeserialize(as = ImmutableServerUsageCreateCommand.class)
+public abstract class ServerUsageCreateCommand implements Command {
+
+    public abstract long serverId();
+
+    @Value.Default
+    public String environment() {
+        return "PROD";
+    }
+}

--- a/waltz-service/src/main/java/org/finos/waltz/service/database_information/DatabaseInformationService.java
+++ b/waltz-service/src/main/java/org/finos/waltz/service/database_information/DatabaseInformationService.java
@@ -19,30 +19,44 @@
 package org.finos.waltz.service.database_information;
 
 import org.finos.waltz.common.Checks;
+import org.finos.waltz.common.DateTimeUtilities;
 import org.finos.waltz.data.application.ApplicationIdSelectorFactory;
 import org.finos.waltz.data.database_information.DatabaseInformationDao;
+import org.finos.waltz.model.EntityKind;
 import org.finos.waltz.model.IdSelectionOptions;
+import org.finos.waltz.model.Operation;
+import org.finos.waltz.model.Severity;
+import org.finos.waltz.model.changelog.ChangeLog;
+import org.finos.waltz.model.changelog.ImmutableChangeLog;
 import org.finos.waltz.model.database_information.DatabaseInformation;
 import org.finos.waltz.model.database_information.DatabaseSummaryStatistics;
 import org.finos.waltz.model.entity_search.EntitySearchOptions;
+import org.finos.waltz.service.changelog.ChangeLogService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static org.finos.waltz.common.Checks.checkNotNull;
 
 @Service
 public class DatabaseInformationService {
 
     private final DatabaseInformationDao databaseInformationDao;
+    private final ChangeLogService changeLogService;
     private final ApplicationIdSelectorFactory factory = new ApplicationIdSelectorFactory();
 
     @Autowired
-    public DatabaseInformationService(DatabaseInformationDao databaseInformationDao) {
+    public DatabaseInformationService(DatabaseInformationDao databaseInformationDao,
+                                      ChangeLogService changeLogService) {
         Checks.checkNotNull(databaseInformationDao, "databaseInformationDao cannot be null");
+        Checks.checkNotNull(changeLogService, "changeLogService cannot be null");
         this.databaseInformationDao = databaseInformationDao;
+        this.changeLogService = changeLogService;
     }
 
     public List<DatabaseInformation> findByApplicationId(Long id) {
@@ -76,5 +90,37 @@ public class DatabaseInformationService {
 
     public Long createDatabase(DatabaseInformation info) {
         return databaseInformationDao.createDatabase(info);
+    }
+
+
+    /**
+     * Upserts a batch of database assets (keyed on external id) and records a change-log entry
+     * against each. Databases are part of the asset inventory; associating them with an
+     * application is a separate concern handled via {@link org.finos.waltz.service.database_usage.DatabaseUsageService}.
+     */
+    public Collection<DatabaseInformation> bulkSave(List<DatabaseInformation> databases, String username) {
+        checkNotNull(databases, "databases cannot be null");
+        checkNotNull(username, "username cannot be null");
+        if (databases.stream().anyMatch(d -> !d.externalId().isPresent())) {
+            throw new IllegalArgumentException("every database must have an externalId (used as the upsert key)");
+        }
+
+        Collection<DatabaseInformation> saved = databaseInformationDao.bulkUpsert(databases);
+
+        Collection<ChangeLog> logs = saved
+                .stream()
+                .map(d -> ImmutableChangeLog.builder()
+                        .message(format("Bulk saved database: %s", d.databaseName()))
+                        .parentReference(d.entityReference())
+                        .userId(username)
+                        .createdAt(DateTimeUtilities.nowUtc())
+                        .severity(Severity.INFORMATION)
+                        .childKind(EntityKind.DATABASE)
+                        .operation(Operation.UPDATE)
+                        .build())
+                .collect(Collectors.toList());
+        changeLogService.write(logs);
+
+        return saved;
     }
 }

--- a/waltz-service/src/main/java/org/finos/waltz/service/database_usage/DatabaseUsageService.java
+++ b/waltz-service/src/main/java/org/finos/waltz/service/database_usage/DatabaseUsageService.java
@@ -18,23 +18,38 @@
 
 package org.finos.waltz.service.database_usage;
 
+import org.finos.waltz.common.DateTimeUtilities;
 import org.finos.waltz.data.database_usage.DatabaseUsageDao;
+import org.finos.waltz.model.EntityKind;
 import org.finos.waltz.model.EntityReference;
+import org.finos.waltz.model.Operation;
+import org.finos.waltz.model.Severity;
+import org.finos.waltz.model.changelog.ImmutableChangeLog;
 import org.finos.waltz.model.database_usage.DatabaseUsage;
+import org.finos.waltz.model.database_usage.DatabaseUsageCreateCommand;
+import org.finos.waltz.service.changelog.ChangeLogService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 
+import static java.lang.String.format;
+import static org.finos.waltz.common.Checks.checkNotNull;
+
 @Service
 public class DatabaseUsageService {
 
     private final DatabaseUsageDao databaseUsageDao;
+    private final ChangeLogService changeLogService;
 
 
     @Autowired
-    public DatabaseUsageService(DatabaseUsageDao databaseUsageDao) {
+    public DatabaseUsageService(DatabaseUsageDao databaseUsageDao,
+                                ChangeLogService changeLogService) {
+        checkNotNull(databaseUsageDao, "databaseUsageDao cannot be null");
+        checkNotNull(changeLogService, "changeLogService cannot be null");
         this.databaseUsageDao = databaseUsageDao;
+        this.changeLogService = changeLogService;
     }
 
 
@@ -44,6 +59,34 @@ public class DatabaseUsageService {
 
 
     public Collection<DatabaseUsage> findByEntityReference(EntityReference ref) {
+        return databaseUsageDao.findByEntityReference(ref);
+    }
+
+
+    /**
+     * Links the given database assets to an entity (e.g. an application) in the requested
+     * environments, records a change-log entry against that entity, and returns the entity's
+     * resulting usages.
+     */
+    public Collection<DatabaseUsage> addUsages(EntityReference ref,
+                                               Collection<DatabaseUsageCreateCommand> commands,
+                                               String username) {
+        checkNotNull(ref, "ref cannot be null");
+        checkNotNull(commands, "commands cannot be null");
+        checkNotNull(username, "username cannot be null");
+
+        int linkCount = databaseUsageDao.create(ref, commands, username);
+
+        changeLogService.write(ImmutableChangeLog.builder()
+                .message(format("Linked %d database(s)", linkCount))
+                .parentReference(ref)
+                .userId(username)
+                .createdAt(DateTimeUtilities.nowUtc())
+                .severity(Severity.INFORMATION)
+                .childKind(EntityKind.DATABASE)
+                .operation(Operation.ADD)
+                .build());
+
         return databaseUsageDao.findByEntityReference(ref);
     }
 }

--- a/waltz-service/src/main/java/org/finos/waltz/service/server_information/ServerInformationService.java
+++ b/waltz-service/src/main/java/org/finos/waltz/service/server_information/ServerInformationService.java
@@ -18,22 +18,31 @@
 
 package org.finos.waltz.service.server_information;
 
+import org.finos.waltz.common.DateTimeUtilities;
 import org.finos.waltz.data.application.ApplicationIdSelectorFactory;
 import org.finos.waltz.data.server_information.ServerInformationDao;
 import org.finos.waltz.data.server_information.search.ServerInformationSearchDao;
 import org.finos.waltz.model.EntityKind;
 import org.finos.waltz.model.IdSelectionOptions;
+import org.finos.waltz.model.Operation;
+import org.finos.waltz.model.Severity;
+import org.finos.waltz.model.changelog.ChangeLog;
+import org.finos.waltz.model.changelog.ImmutableChangeLog;
 import org.finos.waltz.model.entity_search.EntitySearchOptions;
 import org.finos.waltz.model.server_information.ServerInformation;
 import org.finos.waltz.model.server_information.ServerSummaryBasicStatistics;
 import org.finos.waltz.model.server_information.ServerSummaryStatistics;
+import org.finos.waltz.service.changelog.ChangeLogService;
 import org.jooq.Record1;
 import org.jooq.Select;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.finos.waltz.common.Checks.checkNotNull;
 import static org.finos.waltz.common.StringUtilities.isEmpty;
@@ -45,16 +54,20 @@ public class ServerInformationService {
     private final ApplicationIdSelectorFactory selectorFactory = new ApplicationIdSelectorFactory();
     private final ServerInformationDao serverInformationDao;
     private final ServerInformationSearchDao serverInformationSearchDao;
+    private final ChangeLogService changeLogService;
 
 
     @Autowired
     public ServerInformationService(ServerInformationDao serverInfoDao,
-                                    ServerInformationSearchDao serverInformationSearchDao) {
+                                    ServerInformationSearchDao serverInformationSearchDao,
+                                    ChangeLogService changeLogService) {
         checkNotNull(serverInfoDao, "serverInformationDao must not be null");
         checkNotNull(serverInformationSearchDao, "serverInformationSearchDao cannot be null");
+        checkNotNull(changeLogService, "changeLogService cannot be null");
 
         this.serverInformationDao = serverInfoDao;
         this.serverInformationSearchDao = serverInformationSearchDao;
+        this.changeLogService = changeLogService;
     }
 
     public List<ServerInformation> findByAssetCode(String assetCode) {
@@ -91,6 +104,38 @@ public class ServerInformationService {
         Select<Record1<Long>> selector = selectorFactory.apply(options);
         return serverInformationDao.calculateBasicStatsForAppSelector(selector);
     }
+
+    /**
+     * Upserts a batch of server assets (keyed on external id) and records a change-log entry
+     * against each. Servers are part of the asset inventory; associating them with an
+     * application is a separate concern handled via {@link org.finos.waltz.service.server_usage.ServerUsageService}.
+     */
+    public Collection<ServerInformation> bulkSave(List<ServerInformation> servers, String username) {
+        checkNotNull(servers, "servers cannot be null");
+        checkNotNull(username, "username cannot be null");
+        if (servers.stream().anyMatch(s -> !s.externalId().isPresent())) {
+            throw new IllegalArgumentException("every server must have an externalId (used as the upsert key)");
+        }
+
+        Collection<ServerInformation> saved = serverInformationDao.bulkUpsert(servers);
+
+        Collection<ChangeLog> logs = saved
+                .stream()
+                .map(s -> ImmutableChangeLog.builder()
+                        .message(format("Bulk saved server: %s", s.hostname()))
+                        .parentReference(s.entityReference())
+                        .userId(username)
+                        .createdAt(DateTimeUtilities.nowUtc())
+                        .severity(Severity.INFORMATION)
+                        .childKind(EntityKind.SERVER)
+                        .operation(Operation.UPDATE)
+                        .build())
+                .collect(Collectors.toList());
+        changeLogService.write(logs);
+
+        return saved;
+    }
+
 
     public List<ServerInformation> search(String query) {
         if (isEmpty(query)) return emptyList();

--- a/waltz-service/src/main/java/org/finos/waltz/service/server_usage/ServerUsageService.java
+++ b/waltz-service/src/main/java/org/finos/waltz/service/server_usage/ServerUsageService.java
@@ -18,26 +18,38 @@
 
 package org.finos.waltz.service.server_usage;
 
+import org.finos.waltz.common.DateTimeUtilities;
 import org.finos.waltz.data.server_usage.ServerUsageDao;
+import org.finos.waltz.model.EntityKind;
 import org.finos.waltz.model.EntityReference;
+import org.finos.waltz.model.Operation;
+import org.finos.waltz.model.Severity;
+import org.finos.waltz.model.changelog.ImmutableChangeLog;
 import org.finos.waltz.model.server_usage.ServerUsage;
+import org.finos.waltz.model.server_usage.ServerUsageCreateCommand;
+import org.finos.waltz.service.changelog.ChangeLogService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 
+import static java.lang.String.format;
 import static org.finos.waltz.common.Checks.checkNotNull;
 
 @Service
 public class ServerUsageService {
 
     private final ServerUsageDao serverUsageDao;
+    private final ChangeLogService changeLogService;
 
 
     @Autowired
-    public ServerUsageService(ServerUsageDao serverUsageDao) {
+    public ServerUsageService(ServerUsageDao serverUsageDao,
+                              ChangeLogService changeLogService) {
         checkNotNull(serverUsageDao, "serverUsageDao cannot be null");
+        checkNotNull(changeLogService, "changeLogService cannot be null");
         this.serverUsageDao = serverUsageDao;
+        this.changeLogService = changeLogService;
     }
 
 
@@ -47,6 +59,34 @@ public class ServerUsageService {
 
 
     public Collection<ServerUsage> findByReferencedEntity(EntityReference ref) {
+        return serverUsageDao.findByReferencedEntity(ref);
+    }
+
+
+    /**
+     * Links the given server assets to an entity (e.g. an application) in the requested
+     * environments, records a change-log entry against that entity, and returns the entity's
+     * resulting usages.
+     */
+    public Collection<ServerUsage> addUsages(EntityReference ref,
+                                             Collection<ServerUsageCreateCommand> commands,
+                                             String username) {
+        checkNotNull(ref, "ref cannot be null");
+        checkNotNull(commands, "commands cannot be null");
+        checkNotNull(username, "username cannot be null");
+
+        int linkCount = serverUsageDao.create(ref, commands, username);
+
+        changeLogService.write(ImmutableChangeLog.builder()
+                .message(format("Linked %d server(s)", linkCount))
+                .parentReference(ref)
+                .userId(username)
+                .createdAt(DateTimeUtilities.nowUtc())
+                .severity(Severity.INFORMATION)
+                .childKind(EntityKind.SERVER)
+                .operation(Operation.ADD)
+                .build());
+
         return serverUsageDao.findByReferencedEntity(ref);
     }
 }

--- a/waltz-web/src/main/java/org/finos/waltz/web/WebUtilities.java
+++ b/waltz-web/src/main/java/org/finos/waltz/web/WebUtilities.java
@@ -238,7 +238,9 @@ public class WebUtilities {
 
 
     public static <T> List<T> readList(Request request, Class<T> itemClass) throws IOException {
-        return (List<T>) readBody(request, List.class);
+        return getJsonMapper().readValue(
+                request.bodyAsBytes(),
+                getJsonMapper().getTypeFactory().constructCollectionType(List.class, itemClass));
     }
 
 

--- a/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/DatabaseInformationEndpoint.java
+++ b/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/DatabaseInformationEndpoint.java
@@ -19,6 +19,7 @@
 package org.finos.waltz.web.endpoints.api;
 
 import org.finos.waltz.service.database_information.DatabaseInformationService;
+import org.finos.waltz.service.user.UserRoleService;
 import org.finos.waltz.web.DatumRoute;
 import org.finos.waltz.web.ListRoute;
 import org.finos.waltz.web.endpoints.Endpoint;
@@ -26,23 +27,33 @@ import org.finos.waltz.web.json.ApplicationDatabases;
 import org.finos.waltz.web.json.ImmutableApplicationDatabases;
 import org.finos.waltz.model.database_information.DatabaseInformation;
 import org.finos.waltz.model.database_information.DatabaseSummaryStatistics;
+import org.finos.waltz.model.user.SystemRole;
 import org.finos.waltz.web.WebUtilities;
 import org.finos.waltz.web.endpoints.EndpointUtilities;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.finos.waltz.common.Checks.checkNotNull;
 
 @Service
 public class DatabaseInformationEndpoint implements Endpoint {
 
     private final DatabaseInformationService databaseInformationService;
+    private final UserRoleService userRoleService;
 
     private static final String BASE_URL = WebUtilities.mkPath("api", "database");
 
     @Autowired
-    public DatabaseInformationEndpoint(DatabaseInformationService databaseInformationService) {
+    public DatabaseInformationEndpoint(DatabaseInformationService databaseInformationService,
+                                       UserRoleService userRoleService) {
+        checkNotNull(databaseInformationService, "databaseInformationService cannot be null");
+        checkNotNull(userRoleService, "userRoleService cannot be null");
         this.databaseInformationService = databaseInformationService;
+        this.userRoleService = userRoleService;
     }
 
     @Override
@@ -53,6 +64,7 @@ public class DatabaseInformationEndpoint implements Endpoint {
         String getByExternalIdPath = WebUtilities.mkPath(BASE_URL, "external-id", ":externalId");
         String findForAppSelectorPath = WebUtilities.mkPath(BASE_URL);
         String calculateStatsForAppIdSelectorPath = WebUtilities.mkPath(BASE_URL, "stats");
+        String bulkSavePath = WebUtilities.mkPath(BASE_URL, "bulk");
 
 
         ListRoute<DatabaseInformation> findForAppRoute = (request, response)
@@ -77,10 +89,18 @@ public class DatabaseInformationEndpoint implements Endpoint {
         DatumRoute<DatabaseSummaryStatistics> calculateStatsForAppIdSelectorRoute = (request, response)
                 -> databaseInformationService.calculateStatsForAppIdSelector(WebUtilities.readIdSelectionOptionsFromBody(request));
 
+        DatumRoute<Collection<DatabaseInformation>> bulkSaveRoute = (request, response) -> {
+            WebUtilities.requireRole(userRoleService, request, SystemRole.ADMIN);
+            String username = WebUtilities.getUsername(request);
+            List<DatabaseInformation> databases = WebUtilities.readList(request, DatabaseInformation.class);
+            return databaseInformationService.bulkSave(databases, username);
+        };
+
 
         EndpointUtilities.getForList(findForAppPath, findForAppRoute);
         EndpointUtilities.postForList(findForAppSelectorPath, findForAppSelectorRoute);
         EndpointUtilities.postForDatum(calculateStatsForAppIdSelectorPath, calculateStatsForAppIdSelectorRoute);
+        EndpointUtilities.postForDatum(bulkSavePath, bulkSaveRoute);
         EndpointUtilities.getForDatum(getByIdPath, getByIdRoute);
         EndpointUtilities.getForDatum(getByExternalIdPath, getByExternalIdRoute);
 

--- a/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/DatabaseUsageEndpoint.java
+++ b/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/DatabaseUsageEndpoint.java
@@ -19,14 +19,23 @@
 package org.finos.waltz.web.endpoints.api;
 
 import org.finos.waltz.service.database_usage.DatabaseUsageService;
+import org.finos.waltz.service.user.UserRoleService;
+import org.finos.waltz.web.DatumRoute;
 import org.finos.waltz.web.ListRoute;
 import org.finos.waltz.web.endpoints.Endpoint;
 import org.finos.waltz.model.database_usage.DatabaseUsage;
+import org.finos.waltz.model.database_usage.DatabaseUsageCreateCommand;
+import org.finos.waltz.model.user.SystemRole;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
+import java.util.List;
+
 import static org.finos.waltz.web.WebUtilities.*;
 import static org.finos.waltz.web.endpoints.EndpointUtilities.getForList;
+import static org.finos.waltz.web.endpoints.EndpointUtilities.postForDatum;
+import static org.finos.waltz.common.Checks.checkNotNull;
 
 
 @Service
@@ -35,10 +44,15 @@ public class DatabaseUsageEndpoint implements Endpoint {
     private static final String BASE_URL = mkPath("api", "database-usage");
 
     private final DatabaseUsageService databaseUsageService;
+    private final UserRoleService userRoleService;
 
     @Autowired
-    public DatabaseUsageEndpoint(DatabaseUsageService databaseUsageService) {
+    public DatabaseUsageEndpoint(DatabaseUsageService databaseUsageService,
+                                 UserRoleService userRoleService) {
+        checkNotNull(databaseUsageService, "databaseUsageService cannot be null");
+        checkNotNull(userRoleService, "userRoleService cannot be null");
         this.databaseUsageService = databaseUsageService;
+        this.userRoleService = userRoleService;
     }
 
     @Override
@@ -53,8 +67,16 @@ public class DatabaseUsageEndpoint implements Endpoint {
         ListRoute<DatabaseUsage> findByDatabaseIdRoute = (request, response)
                 -> databaseUsageService.findByDatabaseId(getId(request));
 
+        DatumRoute<Collection<DatabaseUsage>> addUsagesRoute = (request, response) -> {
+            requireRole(userRoleService, request, SystemRole.ADMIN);
+            String username = getUsername(request);
+            List<DatabaseUsageCreateCommand> commands = readList(request, DatabaseUsageCreateCommand.class);
+            return databaseUsageService.addUsages(getEntityReference(request), commands, username);
+        };
+
         getForList(findByReferencedEntityPath, findByReferencedEntityRoute);
         getForList(findByDatabaseIdPath, findByDatabaseIdRoute);
+        postForDatum(findByReferencedEntityPath, addUsagesRoute);
     }
 
 }

--- a/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/ServerInformationEndpoint.java
+++ b/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/ServerInformationEndpoint.java
@@ -19,16 +19,21 @@
 package org.finos.waltz.web.endpoints.api;
 
 import org.finos.waltz.service.server_information.ServerInformationService;
+import org.finos.waltz.service.user.UserRoleService;
 import org.finos.waltz.web.DatumRoute;
 import org.finos.waltz.web.ListRoute;
 import org.finos.waltz.web.endpoints.Endpoint;
 import org.finos.waltz.model.server_information.ServerInformation;
 import org.finos.waltz.model.server_information.ServerSummaryBasicStatistics;
 import org.finos.waltz.model.server_information.ServerSummaryStatistics;
+import org.finos.waltz.model.user.SystemRole;
 import org.finos.waltz.web.WebUtilities;
 import org.finos.waltz.web.endpoints.EndpointUtilities;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
 
 import static org.finos.waltz.common.Checks.checkNotNull;
 
@@ -39,13 +44,17 @@ public class ServerInformationEndpoint implements Endpoint {
     private static final String BASE_URL = WebUtilities.mkPath("api", "server-info");
 
     private final ServerInformationService serverInformationService;
+    private final UserRoleService userRoleService;
 
 
     @Autowired
-    public ServerInformationEndpoint(ServerInformationService serverInfoService) {
+    public ServerInformationEndpoint(ServerInformationService serverInfoService,
+                                     UserRoleService userRoleService) {
         checkNotNull(serverInfoService, "serverInformationService must not be null");
+        checkNotNull(userRoleService, "userRoleService cannot be null");
 
         this.serverInformationService = serverInfoService;
+        this.userRoleService = userRoleService;
     }
 
 
@@ -59,6 +68,7 @@ public class ServerInformationEndpoint implements Endpoint {
         String getByHostnamePath = WebUtilities.mkPath(BASE_URL, "hostname", ":hostname");
         String calculateStatsForAppSelectorPath = WebUtilities.mkPath(BASE_URL, "apps", "stats");
         String calculateBasicStatsForAppSelectorPath = WebUtilities.mkPath(calculateStatsForAppSelectorPath, "basic");
+        String bulkSavePath = WebUtilities.mkPath(BASE_URL, "bulk");
 
         ListRoute<ServerInformation> findByAssetCodeRoute = (request, response)
                 -> serverInformationService.findByAssetCode(request.params("assetCode"));
@@ -81,6 +91,13 @@ public class ServerInformationEndpoint implements Endpoint {
         DatumRoute<ServerSummaryBasicStatistics> calculateBasicStatsForAppSelectorRoute = (request, response)
                 -> serverInformationService.calculateBasicStatsForAppSelector(WebUtilities.readIdSelectionOptionsFromBody(request));
 
+        DatumRoute<Collection<ServerInformation>> bulkSaveRoute = (request, response) -> {
+            WebUtilities.requireRole(userRoleService, request, SystemRole.ADMIN);
+            String username = WebUtilities.getUsername(request);
+            List<ServerInformation> servers = WebUtilities.readList(request, ServerInformation.class);
+            return serverInformationService.bulkSave(servers, username);
+        };
+
 
         EndpointUtilities.getForList(findByAssetCodePath, findByAssetCodeRoute);
         EndpointUtilities.getForList(findByAppIdPath, findByAppIdRoute);
@@ -89,6 +106,7 @@ public class ServerInformationEndpoint implements Endpoint {
         EndpointUtilities.getForDatum(getByHostnamePath, getByHostnameRoute);
         EndpointUtilities.postForDatum(calculateStatsForAppSelectorPath, calculateStatsForAppSelectorRoute);
         EndpointUtilities.postForDatum(calculateBasicStatsForAppSelectorPath, calculateBasicStatsForAppSelectorRoute);
+        EndpointUtilities.postForDatum(bulkSavePath, bulkSaveRoute);
     }
 
 

--- a/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/ServerUsageEndpoint.java
+++ b/waltz-web/src/main/java/org/finos/waltz/web/endpoints/api/ServerUsageEndpoint.java
@@ -19,14 +19,22 @@
 package org.finos.waltz.web.endpoints.api;
 
 import org.finos.waltz.service.server_usage.ServerUsageService;
+import org.finos.waltz.service.user.UserRoleService;
+import org.finos.waltz.web.DatumRoute;
 import org.finos.waltz.web.ListRoute;
 import org.finos.waltz.web.endpoints.Endpoint;
 import org.finos.waltz.model.server_usage.ServerUsage;
+import org.finos.waltz.model.server_usage.ServerUsageCreateCommand;
+import org.finos.waltz.model.user.SystemRole;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
+import java.util.List;
+
 import static org.finos.waltz.web.WebUtilities.*;
 import static org.finos.waltz.web.endpoints.EndpointUtilities.getForList;
+import static org.finos.waltz.web.endpoints.EndpointUtilities.postForDatum;
 import static org.finos.waltz.common.Checks.checkNotNull;
 
 
@@ -36,12 +44,16 @@ public class ServerUsageEndpoint implements Endpoint {
     private static final String BASE_URL = mkPath("api", "server-usage");
 
     private final ServerUsageService serverUsageService;
+    private final UserRoleService userRoleService;
 
 
     @Autowired
-    public ServerUsageEndpoint(ServerUsageService serverUsageService) {
+    public ServerUsageEndpoint(ServerUsageService serverUsageService,
+                               UserRoleService userRoleService) {
         checkNotNull(serverUsageService, "serverUsageService cannot be null");
+        checkNotNull(userRoleService, "userRoleService cannot be null");
         this.serverUsageService = serverUsageService;
+        this.userRoleService = userRoleService;
     }
 
 
@@ -57,8 +69,16 @@ public class ServerUsageEndpoint implements Endpoint {
         ListRoute<ServerUsage> findByServerIdRoute = (request, response)
                 -> serverUsageService.findByServerId(getId(request));
 
+        DatumRoute<Collection<ServerUsage>> addUsagesRoute = (request, response) -> {
+            requireRole(userRoleService, request, SystemRole.ADMIN);
+            String username = getUsername(request);
+            List<ServerUsageCreateCommand> commands = readList(request, ServerUsageCreateCommand.class);
+            return serverUsageService.addUsages(getEntityReference(request), commands, username);
+        };
+
         getForList(findByReferencedEntityPath, findByReferencedEntityRoute);
         getForList(findByServerIdPath, findByServerIdRoute);
+        postForDatum(findByReferencedEntityPath, addUsagesRoute);
     }
 
 }


### PR DESCRIPTION
## What

Adds REST create endpoints (with supporting service/DAO methods and two new create-command models) for server and database information/usage:

- `POST /api/database-usage/ref/:kind/:id` — link one or more existing databases to an entity (batch); body: `[{ databaseId, environment }]`
- `POST /api/server-usage/ref/:kind/:id` — link one or more existing servers to an entity (batch); body: `[{ serverId, environment }]`
- create endpoints for database-information and server-information

The usage create-commands (`DatabaseUsageCreateCommand`, `ServerUsageCreateCommand`) intentionally carry only `databaseId`/`serverId` + `environment`. The owning entity is supplied via the path as a generic `EntityReference` (`:kind/:id`), consistent with the existing `findByEntityReference` read side and allowing batch creation of several usages against a single entity (and any entity kind, not just applications).

## Why

Supports #7573 (Playwright e2e: Technology) by allowing the Technology-related test data — servers, databases and their usages — to be seeded via the API.

## Testing

- Builds cleanly (waltz-model / data / service / web).
- Exercised via the dual (Postgres + MSSQL) build.
