### PR TITLE
7600: Stop logging the Authorization header and decoded JWT

### DIFF
--- a/waltz-web/src/main/java/org/finos/waltz/web/endpoints/auth/JWTAuthenticationFilter.java
+++ b/waltz-web/src/main/java/org/finos/waltz/web/endpoints/auth/JWTAuthenticationFilter.java
@@ -60,21 +60,16 @@ public class JWTAuthenticationFilter extends WaltzFilter {
     @Override
     public void handle(Request request, Response response) throws Exception {
         String authorizationHeader = request.headers("Authorization");
-        LOG.info("authorizationHeader : {} ", authorizationHeader);
 
         if (authorizationHeader == null) {
             AuthenticationUtilities.setUserAsAnonymous(request);
         } else {
             String token = authorizationHeader.replaceFirst("Bearer ", "");
             DecodedJWT decodedToken = JWT.decode(token);
-            LOG.info("decodedToken : {} ", decodedToken);
 
             JWTVerifier verifier = selectVerifier(decodedToken);
-            LOG.info("verifier : {} ", verifier);
 
             DecodedJWT decodedJWT = verifier.verify(token);
-            LOG.info("decodedJWT : {} ", decodedJWT);
-            LOG.info("subject : {} ", decodedJWT.getSubject());
 
             AuthenticationUtilities.setUser(request, decodedJWT.getSubject());
         }
@@ -91,7 +86,6 @@ public class JWTAuthenticationFilter extends WaltzFilter {
 
     private JWTVerifier selectVerifier(DecodedJWT decodedToken) {
         String algorithm = decodedToken.getAlgorithm();
-        LOG.info("algorithm : {} ", algorithm);
 
         switch (algorithm) {
             case "HS256":


### PR DESCRIPTION
## What

Removes the `INFO`-level log statements in `JWTAuthenticationFilter` that printed the incoming `Authorization` header, the decoded token, the verifier, the decoded JWT and its subject on every authenticated request, plus a debug log of the token algorithm.

## Why

These lines wrote bearer credentials into the application logs, where they can be collected by log aggregation and read by anyone with log access. A token recovered from the logs can be replayed to impersonate the user until it expires, and logging credentials is a data-hygiene concern for regulated deployments.

## Notes

No behaviour change beyond logging. If request diagnostics are needed, only non-sensitive fields (for example the resolved username) should be logged at `DEBUG` — never the raw header or token.

Closes #7600
