### PR TITLE
7576: Add Playwright e2e coverage for Surveys

### DIFF
--- a/waltz-e2e/tests/helpers/survey.js
+++ b/waltz-e2e/tests/helpers/survey.js
@@ -1,0 +1,351 @@
+import { expect } from "@playwright/test";
+import { apiContext } from "./api.js";
+
+/**
+ * Survey seeding + UI helpers.
+ *
+ * Surveys are the deepest area to seed: a completable instance needs a template
+ * with questions, an active status, a run bound to a selector + involvement
+ * kind, and a recipient Person. There is no create-person endpoint, but the
+ * `admin` login is itself a feed-loaded Person, so we make admin the recipient
+ * (via an involvement) and drive the whole lifecycle as that person. See the
+ * README "Known seeding gaps".
+ */
+
+/**
+ * The `admin` login maps to a real Person record. Survey recipients/owners are
+ * Persons, so look it up rather than hardcoding the sample id.
+ */
+export async function getAdminPerson(ctx) {
+    const resp = await ctx.get("/api/person/search/admin");
+    const people = await resp.json();
+    const person = people.find(p => p.userId === "admin" || p.email === "admin") ?? people[0];
+    if (!person) {
+        throw new Error("could not resolve the 'admin' person record");
+    }
+    return person;
+}
+
+/**
+ * Find any active Person other than `excludeId`, for reassignment scenarios.
+ * Person search matches on name substrings, so try a few common fragments.
+ */
+export async function findOtherPerson(ctx, excludeId) {
+    for (const fragment of ["smi", "ell", "ann", "art", "son", "ley", "ric", "and"]) {
+        const resp = await ctx.get(`/api/person/search/${fragment}`);
+        if (!resp.ok()) {
+            continue;
+        }
+        const people = await resp.json();
+        const person = people.find(p => p.id !== excludeId && p.userId !== "admin");
+        if (person) {
+            return person;
+        }
+    }
+    throw new Error("could not find an alternative person via search");
+}
+
+/**
+ * An involvement kind whose subject is APPLICATION — needed both to link admin
+ * to an app and to appear in the run-create wizard's kind picker (it filters to
+ * the template's target kind). Returns the full kind {id, name, subjectKind}.
+ */
+export async function applicationInvolvementKind(ctx) {
+    const resp = await ctx.get("/api/involvement-kind");
+    const kinds = await resp.json();
+    const kind = kinds.find(k => k.subjectKind === "APPLICATION") ?? kinds[0];
+    return kind;
+}
+
+/** Link a person to an application via an involvement kind. */
+export async function addAppInvolvement(ctx, appId, personId, involvementKindId) {
+    const resp = await ctx.post(`/api/involvement/entity/APPLICATION/${appId}`, {
+        data: {
+            operation: "ADD",
+            personEntityRef: { kind: "PERSON", id: personId },
+            involvementKindId
+        }
+    });
+    if (!resp.ok()) {
+        throw new Error(`add involvement failed: ${resp.status()} ${await resp.text()}`);
+    }
+}
+
+/**
+ * Create a public app group with a searchable name. `POST /api/app-group`
+ * ignores its body (it always makes a default-named private group), so rename
+ * it via the overview endpoint and make it public so entity search finds it.
+ * Returns {id, name}.
+ */
+export async function createAppGroup(ctx, name) {
+    const created = await ctx.post("/api/app-group", { data: {} });
+    if (!created.ok()) {
+        throw new Error(`create app group failed: ${created.status()} ${await created.text()}`);
+    }
+    const id = (await created.json());
+    const groupId = id.id ?? id;
+    const renamed = await ctx.post(`/api/app-group/id/${groupId}`, {
+        data: { id: groupId, name, description: name, appGroupKind: "PUBLIC" }
+    });
+    if (!renamed.ok()) {
+        throw new Error(`rename app group failed: ${renamed.status()} ${await renamed.text()}`);
+    }
+    return { id: groupId, name };
+}
+
+/** Add an application to an app group (body is a raw application id). */
+export async function addAppToGroup(ctx, groupId, appId) {
+    const resp = await ctx.post(`/api/app-group/id/${groupId}/applications`, { data: appId });
+    if (!resp.ok()) {
+        throw new Error(`add app to group failed: ${resp.status()} ${await resp.text()}`);
+    }
+}
+
+/** Create a survey template. Returns its id. */
+export async function createTemplate(ctx, { name, externalId, targetEntityKind = "APPLICATION" }) {
+    const resp = await ctx.post("/api/survey-template", {
+        data: { name, description: name, targetEntityKind, externalId, issuanceRole: null }
+    });
+    if (!resp.ok()) {
+        throw new Error(`create template failed: ${resp.status()} ${await resp.text()}`);
+    }
+    return resp.json();
+}
+
+/** Add a question to a template. Returns its id. */
+export async function addQuestion(ctx, {
+    templateId,
+    questionText,
+    externalId,
+    fieldType = "BOOLEAN",
+    isMandatory = false,
+    position = 1,
+    inclusionPredicate = null,
+    allowComment = true
+}) {
+    const question = { surveyTemplateId: templateId, questionText, externalId, fieldType, isMandatory, position, allowComment };
+    if (inclusionPredicate) {
+        question.inclusionPredicate = inclusionPredicate;
+    }
+    const resp = await ctx.post("/api/survey-question", { data: { question, dropdownEntries: [] } });
+    if (!resp.ok()) {
+        throw new Error(`add question failed: ${resp.status()} ${await resp.text()}`);
+    }
+    return resp.json();
+}
+
+/** Move a template to a release status (DRAFT / ACTIVE / OBSOLETE). */
+export async function setTemplateStatus(ctx, templateId, newStatus) {
+    const resp = await ctx.put(`/api/survey-template/${templateId}/status`, { data: { newStatus } });
+    if (!resp.ok()) {
+        throw new Error(`template status change failed: ${resp.status()} ${await resp.text()}`);
+    }
+}
+
+/** Create a survey run against an application selector. Returns the run id. */
+export async function createRun(ctx, {
+    templateId,
+    selectorRef,
+    involvementKindIds = [],
+    ownerInvKindIds = [],
+    issuanceKind = "INDIVIDUAL",
+    name = "e2e survey run",
+    dueDate = "2030-01-01",
+    approvalDueDate = "2030-02-01",
+    contactEmail = "e2e@waltz.test"
+}) {
+    const resp = await ctx.post("/api/survey-run", {
+        data: {
+            name,
+            description: name,
+            surveyTemplateId: templateId,
+            selectionOptions: { entityReference: selectorRef, scope: "EXACT" },
+            involvementKindIds,
+            ownerInvKindIds,
+            dueDate,
+            approvalDueDate,
+            issuanceKind,
+            contactEmail
+        }
+    });
+    if (!resp.ok()) {
+        throw new Error(`create run failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    return body.id ?? body;
+}
+
+/** Create instances for explicit people and issue the run. */
+export async function issueInstancesTo(ctx, runId, recipientPersonIds, ownerPersonIds = []) {
+    const create = await ctx.post(`/api/survey-run/${runId}/create-instances`, {
+        data: { recipientPersonIds, ownerPersonIds, owningRole: null }
+    });
+    if (!create.ok()) {
+        throw new Error(`create instances failed: ${create.status()} ${await create.text()}`);
+    }
+    const issue = await ctx.put(`/api/survey-run/${runId}/status`, { data: { newStatus: "ISSUED" } });
+    if (!issue.ok()) {
+        throw new Error(`issue run failed: ${issue.status()} ${await issue.text()}`);
+    }
+}
+
+/** The instances belonging to a run. */
+export async function instancesForRun(ctx, runId) {
+    const resp = await ctx.get(`/api/survey-instance/run/${runId}`);
+    if (!resp.ok()) {
+        throw new Error(`list instances failed: ${resp.status()} ${await resp.text()}`);
+    }
+    return resp.json();
+}
+
+/** Current status of an instance. */
+export async function instanceStatus(ctx, instanceId) {
+    const resp = await ctx.get(`/api/survey-instance/id/${instanceId}`);
+    if (!resp.ok()) {
+        throw new Error(`get instance failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    return body.status;
+}
+
+/** Drive an instance status transition via REST (for seeding a start state). */
+export async function changeStatus(ctx, instanceId, action, reason = "e2e") {
+    const resp = await ctx.put(`/api/survey-instance/${instanceId}/status`, { data: { action, reason } });
+    if (!resp.ok()) {
+        throw new Error(`status change (${action}) failed: ${resp.status()} ${await resp.text()}`);
+    }
+}
+
+/**
+ * Grant the survey roles the tests need to the shared admin user, preserving
+ * any existing roles (never REPLACE — that would race other specs).
+ */
+export async function grantSurveyRoles(ctx) {
+    const who = await (await ctx.get("/api/user/whoami")).json();
+    const roles = new Set([...(who.roles ?? []), "SURVEY_TEMPLATE_ADMIN", "SURVEY_ADMIN"]);
+    const resp = await ctx.post(`/api/user/${who.userName}/roles`, {
+        data: { roles: [...roles], comment: "waltz-e2e survey tests" }
+    });
+    if (!resp.ok()) {
+        throw new Error(`grant roles failed: ${resp.status()} ${await resp.text()}`);
+    }
+}
+
+/**
+ * Seed a fully-issued survey instance whose recipient is the admin person, so
+ * the browser session (logged in as admin) can drive the response lifecycle.
+ *
+ * Returns { runId, instanceId, appId, appName, groupId, groupName, adminPersonId,
+ *           involvementKindId, templateId }.
+ */
+export async function seedIssuedSurveyForAdmin(baseURL, token, {
+    createApp,
+    uniqueName,
+    questions = [{ questionText: "In scope?", fieldType: "BOOLEAN" }],
+    issuanceKind = "INDIVIDUAL"
+}) {
+    const ctx = await apiContext(baseURL, token);
+    try {
+        const admin = await getAdminPerson(ctx);
+        const involvementKind = await applicationInvolvementKind(ctx);
+        const involvementKindId = involvementKind.id;
+
+        const app = await createApp(baseURL, token, uniqueName("ts_survey_app"));
+        await addAppInvolvement(ctx, app.id, admin.id, involvementKindId);
+
+        const templateId = await createTemplate(ctx, {
+            name: uniqueName("ts_survey_tmpl"),
+            externalId: uniqueName("TS_TMPL")
+        });
+        let position = 1;
+        for (const q of questions) {
+            await addQuestion(ctx, {
+                templateId,
+                position: position++,
+                externalId: uniqueName("TS_Q"),
+                ...q
+            });
+        }
+        await setTemplateStatus(ctx, templateId, "ACTIVE");
+
+        const runId = await createRun(ctx, {
+            templateId,
+            selectorRef: { kind: "APPLICATION", id: app.id },
+            involvementKindIds: [involvementKindId],
+            issuanceKind,
+            name: uniqueName("ts_survey_run")
+        });
+        await issueInstancesTo(ctx, runId, [admin.id]);
+
+        const instances = await instancesForRun(ctx, runId);
+        expect(instances.length).toBeGreaterThan(0);
+
+        return {
+            runId,
+            instanceId: instances[0].id,
+            appId: app.id,
+            appName: app.name,
+            adminPersonId: admin.id,
+            adminPersonName: admin.displayName,
+            involvementKind,
+            involvementKindId,
+            templateId
+        };
+    } finally {
+        await ctx.dispose();
+    }
+}
+
+/**
+ * Drive a survey lifecycle action on the Svelte response-view actions panel.
+ *
+ * Actions render as buttons labelled by the action display (Submit / Approve /
+ * Reject / Withdraw / Reopen). Confirm-and-comment actions open a form with a
+ * reason textarea; NOT_REQUIRED actions (Reopen) fire immediately.
+ */
+export async function invokeSurveyAction(page, label, { needsReason = true } = {}) {
+    const actions = page.locator("div.actions");
+    await actions.getByRole("button", { name: label }).click();
+
+    if (needsReason) {
+        const form = page.locator("form:has(textarea.form-control)");
+        await expect(form.locator("textarea.form-control")).toBeVisible();
+        await form.locator("textarea.form-control").fill(`e2e ${label.toLowerCase()}`);
+        await form.getByRole("button", { name: label }).click();
+    }
+}
+
+/**
+ * Pick an option from a Waltz AngularJS ui-select (waltz-entity-selector). Open
+ * the match, type into the currently-visible search box, then click the choice
+ * row containing the token.
+ */
+export async function pickInUiSelect(scope, page, query, token) {
+    await scope.locator(".ui-select-match").click();
+    const search = page.locator("input.ui-select-search:visible");
+    await search.fill(query);
+    await page.locator(".ui-select-choices-row", { hasText: token }).first().click();
+}
+
+/**
+ * Add a person through a Svelte PersonList (used for recipients/owners).
+ * `row` scopes to the containing table row so recipient vs owner is unambiguous.
+ */
+export async function addPersonViaPersonList(row, page, query, personName) {
+    await row.getByRole("button", { name: "Add additional person" }).click();
+    const input = row.locator("input.autocomplete-input");
+    await input.fill(query);
+    const choice = page.locator(".autocomplete-list-item", { hasText: personName });
+    await choice.first().click();
+}
+
+/**
+ * Remove a person from a Svelte PersonList. The remove button is only revealed
+ * on row hover (waltz-visibility-child), so hover the person's row first.
+ */
+export async function removePersonViaPersonList(row, personName) {
+    const item = row.locator("li", { hasText: personName });
+    await item.hover();
+    // The remove button carries no accessible name (icon only); match its class.
+    await item.locator("button.remove:not([disabled])").click();
+}

--- a/waltz-e2e/tests/surveys.spec.js
+++ b/waltz-e2e/tests/surveys.spec.js
@@ -1,0 +1,414 @@
+import { test, expect } from "@playwright/test";
+import { apiContext, authenticate, createApp, login, uniqueName } from "./helpers/api.js";
+import * as survey from "./helpers/survey.js";
+
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+/**
+ * Managing survey templates + issuing/administering surveys requires the
+ * SURVEY_TEMPLATE_ADMIN and SURVEY_ADMIN roles (the ADMIN role does not imply
+ * them in the UI's waltz-has-role checks). Grant them once, preserving any
+ * existing roles.
+ */
+test.beforeAll(async () => {
+    const token = await login(baseURL);
+    const ctx = await apiContext(baseURL, token);
+    await survey.grantSurveyRoles(ctx);
+    await ctx.dispose();
+});
+
+/**
+ * Create a survey template via the UI (Create New form). Leaves the browser on
+ * the template edit page and returns the chosen name/externalId.
+ */
+async function createTemplateViaUi(page, name) {
+    const externalId = uniqueName("TEST_SURVEY");
+
+    await page.goto("/survey/template/list");
+    await page.locator(".btn", { hasText: "Create New" }).click();
+
+    // Required fields missing -> submit hidden, warning shown.
+    const createButton = page.locator("button", { hasText: "Create" });
+    await expect(createButton).toBeHidden();
+    await expect(page.locator(".alert-warning")).toBeVisible();
+
+    await page.fill("#name", name);
+    await page.fill("#externalId", externalId);
+    await page.selectOption("#targetEntityKind", { label: "Application" });
+
+    // Once required fields are populated, submit appears and the warning goes.
+    await expect(createButton).toBeVisible();
+    await expect(page.locator(".alert-warning")).toBeHidden();
+
+    await createButton.click();
+
+    // On success the app navigates to the edit page, which hosts the
+    // Questions section.
+    const questionsSection = page.locator("waltz-section[name=Questions]");
+    await expect(questionsSection).toBeVisible();
+
+    return { name, externalId };
+}
+
+/**
+ * Add a question to a template on the edit page. Assumes the Questions section
+ * is present.
+ */
+async function addQuestionViaUi(page, { questionText, externalId, helpText }) {
+    const questionsSection = page.locator("waltz-section[name=Questions]");
+    await questionsSection.locator(".btn", { hasText: "Add New" }).click();
+
+    const questionForm = questionsSection.locator("form[name=surveyQuestionForm]");
+    const createQuestionButton = questionForm.locator("button", { hasText: "Create" });
+
+    // Question text is required -> submit hidden, warning shown initially.
+    await expect(questionForm.locator(".alert-warning")).toBeVisible();
+    await expect(createQuestionButton).toBeHidden();
+
+    await questionForm.locator("#qText").fill(questionText);
+    await questionForm.locator("#qExternalId").fill(externalId);
+    await questionForm.locator("#qHelpText").fill(helpText);
+    await questionForm.locator("#qFieldType").selectOption({ label: "Boolean" });
+    await questionForm.locator("#qIsMandatory").setChecked(true);
+    // #qPosition is required but pre-filled (defaults to 10) by the controller.
+
+    await expect(createQuestionButton).toBeVisible();
+    await expect(questionForm.locator(".alert-warning")).toBeHidden();
+
+    await createQuestionButton.click();
+}
+
+// ---------------------------------------------------------------------------
+// Template lifecycle (driven entirely through the UI)
+// ---------------------------------------------------------------------------
+
+test("creates a survey template targeting Application", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+
+    const name = uniqueName("ts_survey_tmpl");
+    await createTemplateViaUi(page, name);
+
+    // Landed on the edit page for the new template.
+    await expect(page.getByTestId("header-small")).toHaveText("Edit");
+    await expect(page.locator("#name")).toHaveValue(name);
+});
+
+test("adds a question to a survey template", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+
+    const name = uniqueName("ts_survey_q");
+    await createTemplateViaUi(page, name);
+
+    const questionText = "Simple Question: In Scope?";
+    await addQuestionViaUi(page, {
+        questionText,
+        externalId: uniqueName("SIMPLE_Q"),
+        helpText: "Simple Question Help Text"
+    });
+
+    // Back in the list view, the new question is shown in the overview table.
+    const questionsSection = page.locator("waltz-section[name=Questions]");
+    await expect(questionsSection.locator("td").getByText(questionText)).toBeVisible();
+});
+
+test("activates a template and exposes lifecycle actions", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+
+    const name = uniqueName("ts_survey_life");
+    await createTemplateViaUi(page, name);
+    await addQuestionViaUi(page, {
+        questionText: "Is this in scope?",
+        externalId: uniqueName("IN_SCOPE"),
+        helpText: "Help"
+    });
+
+    // Navigate from the edit page to the template view via the breadcrumb.
+    await page.locator(".waltz-breadcrumbs").getByText(name).click();
+
+    const actions = page.locator(".waltz-page-summary .waltz-section-actions");
+
+    // While DRAFT: "Mark as Active" is offered, the active-only actions are not.
+    const markActive = actions.getByText("Mark as Active");
+    await expect(markActive).toBeVisible();
+    await markActive.click();
+
+    // Once ACTIVE the draft/obsolete/clone actions are available.
+    await expect(actions.getByText("Mark as Obsolete")).toBeVisible();
+    await expect(actions.getByText("Mark as Draft")).toBeVisible();
+    await expect(actions.getByText("Clone")).toBeVisible();
+    await expect(markActive).toBeHidden();
+});
+
+// ---------------------------------------------------------------------------
+// Issuance
+// ---------------------------------------------------------------------------
+
+/**
+ * Issue a survey run through the multi-step create wizard (the bulk,
+ * selector-driven flow). The recipient is derived from an involvement kind, so
+ * the admin person is linked to an application inside the selector app group.
+ */
+test("issues a survey run via the create wizard", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+    const ctx = await apiContext(baseURL, token);
+
+    const admin = await survey.getAdminPerson(ctx);
+    const involvementKind = await survey.applicationInvolvementKind(ctx);
+
+    // Selector app group holding an application that admin is involved with.
+    const app = await createApp(baseURL, token, uniqueName("ts_wiz_app"));
+    await survey.addAppInvolvement(ctx, app.id, admin.id, involvementKind.id);
+    const group = await survey.createAppGroup(ctx, uniqueName("ts_wiz_grp"));
+    await survey.addAppToGroup(ctx, group.id, app.id);
+
+    // Active template to issue.
+    const templateId = await survey.createTemplate(ctx, {
+        name: uniqueName("ts_wiz_tmpl"),
+        externalId: uniqueName("TS_WIZ")
+    });
+    await survey.addQuestion(ctx, { templateId, questionText: "In scope?", externalId: uniqueName("TS_WIZ_Q") });
+    await survey.setTemplateStatus(ctx, templateId, "ACTIVE");
+
+    // --- GENERAL step
+    await page.goto(`/survey/run/template/${templateId}/run-create`);
+    await page.fill("#name", uniqueName("ts_wiz_run"));
+    await page.fill("#email", "e2e@waltz.test");
+    await page.fill("input#dueDate", "2030-01-01");
+    await page.fill("input#approvalDueDate", "2030-02-01");
+    await page.selectOption("#selectorEntityKind", { label: "Application Group" });
+
+    // Selector entity (ui-select) — pick the seeded app group.
+    await survey.pickInUiSelect(page.locator("#selectorEntity"), page, group.name, group.name);
+
+    await page.selectOption("#selectorScope", { label: "Exact" });
+    await page.selectOption("#involvementKinds", { label: involvementKind.name });
+    await page.locator('input[name="issuanceKind"][value="INDIVIDUAL"]').check();
+
+    // The general step stays in the DOM (ng-show) once we advance, so scope the
+    // step buttons to their own components to keep locators unambiguous.
+    await page.locator("waltz-survey-run-create-general").getByRole("button", { name: "Next" }).click();
+
+    // --- RECIPIENT step: the preview lists admin as a derived recipient.
+    const recipientStep = page.locator("waltz-survey-run-create-recipient");
+    await expect(recipientStep.locator("td", { hasText: admin.displayName })).toBeVisible();
+
+    await recipientStep.getByRole("button", { name: "Next" }).click();
+
+    // --- COMPLETED step: issuance confirmation shown.
+    await expect(page.getByTestId("issuance-confirmation")).toBeVisible();
+
+    await ctx.dispose();
+});
+
+/**
+ * Issue an individual survey directly from an application's Surveys section
+ * (the per-entity flow where recipients are picked by hand).
+ */
+test("issues an individual survey from an application page", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+    const ctx = await apiContext(baseURL, token);
+
+    const admin = await survey.getAdminPerson(ctx);
+    const app = await createApp(baseURL, token, uniqueName("ts_ind_app"));
+
+    // Active template to pick in the section form.
+    const templateName = uniqueName("ts_ind_tmpl");
+    const templateId = await survey.createTemplate(ctx, { name: templateName, externalId: uniqueName("TS_IND") });
+    await survey.addQuestion(ctx, { templateId, questionText: "In scope?", externalId: uniqueName("TS_IND_Q") });
+    await survey.setTemplateStatus(ctx, templateId, "ACTIVE");
+
+    // Open the Surveys section on the application view. Section nav buttons carry
+    // a leading space in their accessible name, so match non-exactly.
+    await page.goto(`/application/${app.id}`);
+    await page.getByRole("button", { name: "Surveys" }).click();
+
+    const section = page.locator("waltz-survey-section");
+    await section.getByText("Issue new survey").click();
+
+    // Choose the seeded template (filter narrows the list when many exist).
+    const filter = section.locator('input[type="search"]');
+    if (await filter.isVisible()) {
+        await filter.fill(templateName);
+    }
+    // The template rows are hrefless anchors (no link role), so match by text.
+    await section.locator("td a", { hasText: templateName }).click();
+
+    // Fill the run form: name defaults from the template; email + due date required.
+    const runForm = section.locator("form[name=runForm]");
+    await runForm.locator("input[type=text]").first().fill(uniqueName("ts_ind_run"));
+    await runForm.locator("input[type=text]").nth(1).fill("e2e@waltz.test");
+    await runForm.locator("input#dueDate").fill("2030-01-01");
+
+    // Add admin as an individual recipient via the user pick list.
+    const recipientPicker = section.locator("waltz-user-pick-list").first();
+    await recipientPicker.getByRole("button", { name: "Add" }).click();
+    await survey.pickInUiSelect(recipientPicker, page, admin.displayName, admin.displayName);
+    await recipientPicker.getByRole("button", { name: "Save" }).click();
+
+    await runForm.locator('input[name="issuanceKind"][value="INDIVIDUAL"]').check();
+    await runForm.getByRole("button", { name: "Issue survey" }).click();
+
+    // Back in the section list, the issued survey appears.
+    await expect(section.getByText(admin.displayName).first()).toBeVisible();
+
+    await ctx.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Instance lifecycle (submit / approve / reject / reopen / withdraw)
+// ---------------------------------------------------------------------------
+
+test("submits and approves a survey response", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+    const ctx = await apiContext(baseURL, token);
+
+    const seed = await survey.seedIssuedSurveyForAdmin(baseURL, token, { createApp, uniqueName });
+
+    await page.goto(`/survey/instance/${seed.instanceId}/response/view`);
+
+    await survey.invokeSurveyAction(page, "Submit");
+    await expect.poll(() => survey.instanceStatus(ctx, seed.instanceId)).toBe("COMPLETED");
+
+    await survey.invokeSurveyAction(page, "Approve");
+    await expect.poll(() => survey.instanceStatus(ctx, seed.instanceId)).toBe("APPROVED");
+
+    await ctx.dispose();
+});
+
+test("rejects, reopens and withdraws a survey response", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+    const ctx = await apiContext(baseURL, token);
+
+    const seed = await survey.seedIssuedSurveyForAdmin(baseURL, token, { createApp, uniqueName });
+    // Advance to COMPLETED via REST so the view opens with approve/reject offered.
+    await survey.changeStatus(ctx, seed.instanceId, "SUBMITTING");
+
+    await page.goto(`/survey/instance/${seed.instanceId}/response/view`);
+
+    await survey.invokeSurveyAction(page, "Reject");
+    await expect.poll(() => survey.instanceStatus(ctx, seed.instanceId)).toBe("REJECTED");
+
+    // Reopen needs no reason (NOT_REQUIRED) and fires immediately.
+    await survey.invokeSurveyAction(page, "Reopen", { needsReason: false });
+    await expect.poll(() => survey.instanceStatus(ctx, seed.instanceId)).toBe("IN_PROGRESS");
+
+    await survey.invokeSurveyAction(page, "Withdraw");
+    await expect.poll(() => survey.instanceStatus(ctx, seed.instanceId)).toBe("WITHDRAWN");
+
+    await ctx.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Reassignment of recipients + owners
+// ---------------------------------------------------------------------------
+
+test("reassigns recipients and owners on an instance", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+    const ctx = await apiContext(baseURL, token);
+
+    const seed = await survey.seedIssuedSurveyForAdmin(baseURL, token, { createApp, uniqueName });
+    const other = await survey.findOtherPerson(ctx, seed.adminPersonId);
+
+    await page.goto(`/survey/instance/${seed.instanceId}/response/view`);
+
+    const peopleTable = page.locator("table:has(td:has-text('Recipients')):has(td:has-text('Individual Approvers'))");
+    const recipientRow = peopleTable.locator("tr", { hasText: "Recipients" });
+    const ownerRow = peopleTable.locator("tr", { hasText: "Individual Approvers" });
+
+    // Add the other person as a recipient, then remove them.
+    await survey.addPersonViaPersonList(recipientRow, page, other.displayName, other.displayName);
+    await expect(recipientRow.getByText(other.displayName)).toBeVisible();
+    await survey.removePersonViaPersonList(recipientRow, other.displayName);
+    await expect(recipientRow.getByText(other.displayName)).toBeHidden();
+
+    // Add the other person as an individual approver (owner), then remove them.
+    await survey.addPersonViaPersonList(ownerRow, page, other.displayName, other.displayName);
+    await expect(ownerRow.getByText(other.displayName)).toBeVisible();
+    await survey.removePersonViaPersonList(ownerRow, other.displayName);
+    await expect(ownerRow.getByText(other.displayName)).toBeHidden();
+
+    await ctx.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Inclusion predicates
+// ---------------------------------------------------------------------------
+
+/**
+ * A question with an inclusion predicate is hidden until its predicate is
+ * satisfied. Q2 is gated on Q1 being checked; answering Q1 reveals Q2 live
+ * (the edit form re-fetches the visible questions after each save).
+ */
+test("inclusion predicate reveals a dependent question", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+    const ctx = await apiContext(baseURL, token);
+
+    const gateExternalId = uniqueName("TS_GATE");
+    const seed = await survey.seedIssuedSurveyForAdmin(baseURL, token, {
+        createApp,
+        uniqueName,
+        questions: [
+            { questionText: "Gate question?", fieldType: "BOOLEAN", externalId: gateExternalId },
+            { questionText: "Follow-up detail", fieldType: "TEXT", inclusionPredicate: `isChecked('${gateExternalId}')` }
+        ]
+    });
+
+    await page.goto(`/survey/instance/${seed.instanceId}/response/edit`);
+
+    const form = page.locator("form[name=surveyResponseForm]");
+    const gate = form.locator(".waltz-survey-question-edit-row", { hasText: "Gate question?" });
+    await expect(gate).toBeVisible();
+    // The gated question is not shown until the predicate is satisfied.
+    await expect(form.getByText("Follow-up detail")).toBeHidden();
+
+    // Answer the gate "Yes" -> the dependent question appears.
+    await gate.locator('input[type=radio][value="true"]').check();
+    await expect(form.getByText("Follow-up detail")).toBeVisible();
+
+    await ctx.dispose();
+});
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+test("exports a run and an individual response", async ({ page, context }) => {
+    const token = await login(baseURL);
+    await authenticate(context, token);
+    const ctx = await apiContext(baseURL, token);
+
+    const seed = await survey.seedIssuedSurveyForAdmin(baseURL, token, { createApp, uniqueName });
+
+    // --- Run-level export (from the run view "Instances" section actions). The
+    // dropdown menu is appended to <body>, so the CSV item sits outside the
+    // toggle's button-group — open the toggle, then click the visible item.
+    await page.goto(`/survey/run/${seed.runId}`);
+    await page.locator(".btn-group", { hasText: "Export Progress" }).getByText("Export Progress").click();
+    const [runDownload] = await Promise.all([
+        page.waitForEvent("download"),
+        page.locator(".dropdown-menu:visible").getByText("Export as csv").click()
+    ]);
+    expect(runDownload.suggestedFilename()).toContain(".csv");
+
+    // --- Individual response export (from the response view context panel). This
+    // is a Svelte hover dropdown whose CSV item fires on mousedown.
+    await page.goto(`/survey/instance/${seed.instanceId}/response/view`);
+    const exporter = page.locator("li", { hasText: "Export Survey" }).first();
+    await exporter.hover();
+    const [individualDownload] = await Promise.all([
+        page.waitForEvent("download"),
+        exporter.getByText("Export as csv").click()
+    ]);
+    expect(individualDownload.suggestedFilename()).toContain(".csv");
+
+    await ctx.dispose();
+});


### PR DESCRIPTION
Sub-task of #6071.

Adds Playwright e2e coverage for the **Surveys** area to the `waltz-e2e` suite. Data is seeded through the Waltz REST API (the same endpoints the UI uses); scenarios are driven and verified through the AngularJS/Svelte UI.

## Coverage
- Create a template targeting Application; add a question.
- Activate a template and expose the obsolete/draft/clone lifecycle actions.
- Issue a survey run through the multi-step create wizard (selector-driven, involvement-based recipients).
- Issue an individual survey from an application's Surveys section (per-entity recipient pick).
- Submit, approve, reject, reopen and withdraw a response through the response viewer.
- Reassign recipients and individual approvers on an instance.
- Confirm an inclusion predicate reveals a dependent question once its gate is answered.
- Export a run and an individual response (CSV).

## Notes
- Issuance needs a recipient Person and there is no create-person endpoint. The `admin` login is itself a feed-loaded Person, so it is linked to the target application via an involvement and used as the recipient — this lets the full response lifecycle be driven end-to-end without seeding a new person.
- Survey seeding + shared UI helpers live in `waltz-e2e/tests/helpers/survey.js`.
