### PR TITLE
7572: Add Playwright e2e coverage for Measurables

### DIFF
--- a/waltz-e2e/tests/helpers/measurable.js
+++ b/waltz-e2e/tests/helpers/measurable.js
@@ -1,0 +1,262 @@
+import { expect } from "@playwright/test";
+import { apiContext } from "./api.js";
+
+/**
+ * Measurable-rating seeding + UI helpers.
+ *
+ * To rate an application against a measurable you need an EDITABLE category that
+ * holds a CONCRETE measurable, plus the rating-edit role. The sample data has
+ * neither for `admin`, so we seed our own:
+ *   1. grant TAXONOMY_EDITOR (create measurables) + RATING_EDITOR (rate);
+ *   2. create an editable category (auto-creates an abstract Root measurable);
+ *   3. bulk-apply one concrete measurable under that Root;
+ * after which admin can add/edit/remove ratings, comments, decommission dates
+ * and replacement apps. Allocations remain unreachable (no allocation-scheme
+ * create endpoint — see the measurables spec fixme).
+ */
+
+/** Grant the taxonomy/rating roles, preserving existing roles (never REPLACE). */
+export async function grantMeasurableRoles(ctx) {
+    const who = await (await ctx.get("/api/user/whoami")).json();
+    const roles = new Set([...(who.roles ?? []), "TAXONOMY_EDITOR", "RATING_EDITOR"]);
+    const resp = await ctx.post(`/api/user/${who.userName}/roles`, {
+        data: { roles: [...roles], comment: "waltz-e2e measurable tests" }
+    });
+    if (!resp.ok()) {
+        throw new Error(`grant roles failed: ${resp.status()} ${await resp.text()}`);
+    }
+}
+
+/** A rating scheme id whose items include user-selectable codes (e.g. G/A/R). */
+export async function firstRatingSchemeId(ctx) {
+    const schemes = await (await ctx.get("/api/rating-scheme")).json();
+    return schemes[0].id;
+}
+
+/** Create an editable measurable category. Returns its id. */
+export async function createEditableCategory(ctx, { name, externalId, ratingSchemeId }) {
+    const resp = await ctx.post("/api/measurable-category/save", {
+        data: {
+            name,
+            description: name,
+            externalId,
+            editable: true,
+            ratingEditorRole: "RATING_EDITOR",
+            ratingSchemeId,
+            allowPrimaryRatings: true,
+            isDeprecated: false,
+            icon: "star",
+            lastUpdatedBy: "admin"
+        }
+    });
+    if (!resp.ok()) {
+        throw new Error(`create category failed: ${resp.status()} ${await resp.text()}`);
+    }
+    return resp.json();
+}
+
+/** The measurables belonging to a category. */
+export async function measurablesForCategory(ctx, categoryId) {
+    const all = await (await ctx.get("/api/measurable/all")).json();
+    return all.filter(m => m.categoryId === categoryId);
+}
+
+/**
+ * Add one concrete measurable under a category's Root via taxonomy bulk-apply
+ * (requires TAXONOMY_EDITOR). Returns the created measurable.
+ */
+export async function addConcreteMeasurable(ctx, categoryId, { name, externalId, parentExternalId }) {
+    const tsv = `name\texternalId\tparentExternalId\tdescription\tconcrete\n${name}\t${externalId}\t${parentExternalId}\t${name}\ttrue\n`;
+    const resp = await ctx.post(
+        `/api/taxonomy-management/bulk/apply/MEASURABLE_CATEGORY/${categoryId}?format=TSV&mode=ADD_ONLY`,
+        { headers: { "content-type": "text/plain" }, data: tsv }
+    );
+    if (!resp.ok()) {
+        throw new Error(`bulk apply failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const measurables = await measurablesForCategory(ctx, categoryId);
+    const created = measurables.find(m => m.externalId === externalId);
+    if (!created) {
+        throw new Error(`concrete measurable ${externalId} not found after bulk apply`);
+    }
+    return created;
+}
+
+/**
+ * Seed an editable category with an abstract Root and one concrete leaf under
+ * it. Returns ids/names for both plus the rating scheme.
+ */
+export async function seedRatableTarget(baseURL, token, uniqueName) {
+    const ctx = await apiContext(baseURL, token);
+    try {
+        await grantMeasurableRoles(ctx);
+        const ratingSchemeId = await firstRatingSchemeId(ctx);
+
+        const externalId = uniqueName("E2E_MCAT");
+        const categoryName = uniqueName("e2e measurables");
+        const categoryId = await createEditableCategory(ctx, {
+            name: categoryName,
+            externalId,
+            ratingSchemeId
+        });
+
+        const root = (await measurablesForCategory(ctx, categoryId)).find(m => !m.concrete);
+        const leaf = await addConcreteMeasurable(ctx, categoryId, {
+            name: uniqueName("Concrete Leaf"),
+            externalId: uniqueName("E2E_LEAF"),
+            parentExternalId: root.externalId
+        });
+
+        return {
+            categoryId,
+            categoryName,
+            ratingSchemeId,
+            rootId: root.id,
+            rootName: root.name,
+            measurableId: leaf.id,
+            measurableName: leaf.name,
+            measurableExternalId: leaf.externalId
+        };
+    } finally {
+        await ctx.dispose();
+    }
+}
+
+/** Save a rating code (e.g. "G") for an app against a measurable. */
+export async function saveRating(ctx, appId, measurableId, code) {
+    const resp = await ctx.post(
+        `/api/measurable-rating/entity/APPLICATION/${appId}/measurable/${measurableId}/rating`,
+        { headers: { "content-type": "text/plain" }, data: code }
+    );
+    if (!resp.ok()) {
+        throw new Error(`save rating failed: ${resp.status()} ${await resp.text()}`);
+    }
+    return resp.json();
+}
+
+/** The measurable ratings recorded for an application. */
+export async function ratingsForApp(ctx, appId) {
+    const resp = await ctx.get(`/api/measurable-rating/entity/APPLICATION/${appId}`);
+    if (!resp.ok()) {
+        throw new Error(`list ratings failed: ${resp.status()} ${await resp.text()}`);
+    }
+    return resp.json();
+}
+
+/** The rating code for a given app+measurable, or null. */
+export async function ratingCode(ctx, appId, measurableId) {
+    const ratings = await ratingsForApp(ctx, appId);
+    const match = ratings.find(r => r.measurableId === measurableId);
+    return match ? match.rating : null;
+}
+
+/** The measurable-rating row id for an app+measurable (needed for decommission). */
+export async function ratingId(ctx, appId, measurableId) {
+    const ratings = await ratingsForApp(ctx, appId);
+    const match = ratings.find(r => r.measurableId === measurableId);
+    return match ? match.id : null;
+}
+
+/** Add a planned decommission date to a measurable rating. Returns its id. */
+export async function addDecommission(ctx, measurableRatingId, date) {
+    const resp = await ctx.post(
+        `/api/measurable-rating-planned-decommission/measurable-rating/${measurableRatingId}`,
+        { data: { newVal: date, oldVal: null } }
+    );
+    if (!resp.ok()) {
+        throw new Error(`add decommission failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    return body.id;
+}
+
+// --- UI helpers ------------------------------------------------------------
+
+/** Open an app's "Ratings / Roadmaps" section from the entity sidebar. */
+export async function openRatingsSection(page, appId) {
+    await page.goto(`/application/${appId}`);
+    await page.getByRole("button", { name: "Ratings / Roadmap" }).click();
+}
+
+/** The measurable-rating entity section component on the entity page. */
+export function ratingSection(page) {
+    return page.locator("waltz-measurable-rating-entity-section");
+}
+
+/**
+ * Enter rating edit mode. A rated entity offers an "Edit" link; a fresh one
+ * offers "Add some ratings." — both toggle the editor. Handle either.
+ */
+export async function enterRatingsEdit(page) {
+    const section = ratingSection(page);
+    const edit = section.getByText("Edit", { exact: true });
+    const add = section.getByText("Add some ratings.");
+    await expect(edit.or(add).first()).toBeVisible();
+    if (await edit.count() > 0) {
+        await edit.first().click();
+    } else {
+        await add.first().click();
+    }
+}
+
+/** Expand all collapsed branches in a ratings tree (to reveal leaf overlays). */
+export async function expandRatingTree(page) {
+    for (let i = 0; i < 6; i++) {
+        const toggle = page.locator("li.tree-collapsed > .tree-branch-head").first();
+        if (await toggle.count() === 0) {
+            break;
+        }
+        await toggle.click();
+    }
+}
+
+/** Select a category tab in the ratings edit panel by name. */
+export async function selectCategoryTab(page, categoryName) {
+    const panel = page.locator("waltz-measurable-rating-edit-panel");
+    const tab = panel.locator("label.wt-label").filter({ hasText: categoryName });
+    if (await tab.count() > 0) {
+        await tab.first().click();
+    }
+}
+
+/**
+ * In the ratings edit panel, select a concrete measurable in the tree by name.
+ */
+export async function selectMeasurableInTree(page, measurableName) {
+    await page.locator(".wmt-search-region input[type=search]").fill(measurableName);
+    const leaf = page.locator(".wmrt-label").filter({ hasText: measurableName });
+    // An unrated leaf sits under a collapsed ancestor (only rated ancestors
+    // auto-expand). Expand collapsed branches until the leaf is visible.
+    for (let i = 0; i < 6; i++) {
+        if (await leaf.count() > 0 && await leaf.first().isVisible()) {
+            break;
+        }
+        const toggle = page.locator("li.tree-collapsed > .tree-branch-head").first();
+        if (await toggle.count() === 0) {
+            break;
+        }
+        await toggle.click();
+    }
+    await leaf.first().click();
+}
+
+/**
+ * Set the planned decommission date via the editable-field. Its "Set" trigger
+ * is hover-revealed, and edit mode shows a date picker + Save button.
+ */
+export async function setDecommissionDateViaUi(page, date) {
+    const field = page.locator("waltz-planned-decommission-editor waltz-editable-field").first();
+    await field.hover();
+    await field.getByText("Set", { exact: true }).click();
+    await field.locator("input").first().fill(date);
+    await field.locator("input").first().press("Escape");
+    await field.getByRole("button", { name: "Save" }).click();
+}
+
+/** Pick a rating in the rating picker by its display name (e.g. "Good"). */
+export async function pickRating(page, ratingName) {
+    await page.locator(".waltz-rating-picker .wrp-option")
+        .filter({ hasText: ratingName })
+        .locator("label")
+        .click();
+}

--- a/waltz-e2e/tests/measurables.spec.js
+++ b/waltz-e2e/tests/measurables.spec.js
@@ -1,0 +1,230 @@
+import { test, expect } from "@playwright/test";
+import { apiContext, authenticate, createApp, login, uniqueName } from "./helpers/api.js";
+import * as ms from "./helpers/measurable.js";
+
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+/**
+ * Measurable ratings e2e.
+ *
+ * A measurable rating attaches a rating-scheme item (e.g. "Good"/"Adequate") from a
+ * measurable *category* to an application, against a concrete measurable in that category.
+ *
+ * The sample data has no editable category with a concrete measurable that `admin` may rate,
+ * so each test seeds its own: grant TAXONOMY_EDITOR + RATING_EDITOR, create an editable
+ * category (auto-creates an abstract Root), then bulk-apply one concrete measurable under the
+ * Root. See helpers/measurable.js.
+ */
+
+test("Ratings / Roadmaps section renders the Ratings sub-section for an API-seeded app", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const app = await createApp(baseURL, token, uniqueName("ms_app"));
+
+    await authenticate(context, token);
+    await ms.openRatingsSection(page, app.id);
+
+    await expect(ms.ratingSection(page)).toBeVisible();
+});
+
+test("adds, edits and removes a measurable rating", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const target = await ms.seedRatableTarget(baseURL, token, uniqueName);
+    const app = await createApp(baseURL, token, uniqueName("ms_rate"));
+    const ctx = await apiContext(baseURL, token);
+
+    await authenticate(context, token);
+    // Native confirm() is used by "Remove all mappings".
+    page.on("dialog", d => d.accept());
+    await ms.openRatingsSection(page, app.id);
+
+    // Enter edit mode, pick the concrete measurable, choose a rating.
+    await ms.enterRatingsEdit(page);
+    await ms.selectCategoryTab(page, target.categoryName);
+    await ms.selectMeasurableInTree(page, target.measurableName);
+    await ms.pickRating(page, "Good");
+    await expect.poll(() => ms.ratingCode(ctx, app.id, target.measurableId)).toBe("G");
+
+    // Edit the rating to a different value (re-select the node after the save reload).
+    await ms.selectMeasurableInTree(page, target.measurableName);
+    await ms.pickRating(page, "Adequate");
+    await expect.poll(() => ms.ratingCode(ctx, app.id, target.measurableId)).toBe("A");
+
+    // Remove the rating (Remove all mappings for the category).
+    await page.getByText("Remove all mappings").click();
+    await expect.poll(() => ms.ratingCode(ctx, app.id, target.measurableId)).toBeNull();
+
+    await ctx.dispose();
+});
+
+test("adds and updates a comment on a measurable rating", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const target = await ms.seedRatableTarget(baseURL, token, uniqueName);
+    const app = await createApp(baseURL, token, uniqueName("ms_comment"));
+    const ctx = await apiContext(baseURL, token);
+    // Rating must exist before a comment can be attached.
+    await ms.saveRating(ctx, app.id, target.measurableId, "G");
+
+    await authenticate(context, token);
+    await ms.openRatingsSection(page, app.id);
+    await ms.enterRatingsEdit(page);
+    await ms.selectCategoryTab(page, target.categoryName);
+    await ms.selectMeasurableInTree(page, target.measurableName);
+
+    // The comment editor is a waltz-inline-edit-area in the rating editor panel.
+    const commentArea = page.locator("waltz-inline-edit-area").first();
+    await commentArea.getByText("Edit").click();
+    await commentArea.locator("textarea").fill("initial comment");
+    await commentArea.getByRole("button", { name: "Save" }).click();
+    await expect.poll(async () => {
+        const r = (await ms.ratingsForApp(ctx, app.id)).find(x => x.measurableId === target.measurableId);
+        return r?.description;
+    }).toBe("initial comment");
+
+    // Update it.
+    await commentArea.getByText("Edit").click();
+    await commentArea.locator("textarea").fill("updated comment");
+    await commentArea.getByRole("button", { name: "Save" }).click();
+    await expect.poll(async () => {
+        const r = (await ms.ratingsForApp(ctx, app.id)).find(x => x.measurableId === target.measurableId);
+        return r?.description;
+    }).toBe("updated comment");
+
+    await ctx.dispose();
+});
+
+test("adds and revokes a decommission date with its icon overlay", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const target = await ms.seedRatableTarget(baseURL, token, uniqueName);
+    const app = await createApp(baseURL, token, uniqueName("ms_decomm"));
+    const ctx = await apiContext(baseURL, token);
+    await ms.saveRating(ctx, app.id, target.measurableId, "G");
+
+    await authenticate(context, token);
+    // Revoke uses a native confirm().
+    page.on("dialog", d => d.accept());
+    await ms.openRatingsSection(page, app.id);
+    await ms.enterRatingsEdit(page);
+    await ms.selectCategoryTab(page, target.categoryName);
+    await ms.selectMeasurableInTree(page, target.measurableName);
+
+    // The decommission editor appears once a rating exists. Set a date.
+    const decommEditor = page.locator("waltz-planned-decommission-editor");
+    await ms.setDecommissionDateViaUi(page, "2031-06-01");
+
+    // Decommission (no replacement) overlay appears on the tree node.
+    await expect(page.locator(".wmrt-node .fa-hand-paper-o").first()).toBeVisible();
+    await expect.poll(async () => {
+        const decs = await (await ctx.get(`/api/measurable-rating-planned-decommission/entity/APPLICATION/${app.id}`)).json();
+        return decs.length;
+    }).toBeGreaterThan(0);
+
+    // Revoke it — re-select the node (the editor collapses after the save) then
+    // the decommission is removed and the overlay disappears.
+    await ms.selectMeasurableInTree(page, target.measurableName);
+    await decommEditor.getByText("Revoke the decommissioning").click();
+    await expect.poll(async () => {
+        const decs = await (await ctx.get(`/api/measurable-rating-planned-decommission/entity/APPLICATION/${app.id}`)).json();
+        return decs.length;
+    }).toBe(0);
+    await ms.openRatingsSection(page, app.id);
+    await expect(page.locator(".wmrt-node .fa-hand-paper-o")).toHaveCount(0);
+
+    await ctx.dispose();
+});
+
+test("adds and removes a replacement application with its icon overlay", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const target = await ms.seedRatableTarget(baseURL, token, uniqueName);
+    const app = await createApp(baseURL, token, uniqueName("ms_repl_src"));
+    const replacement = await createApp(baseURL, token, uniqueName("ms_repl_dst"));
+    const ctx = await apiContext(baseURL, token);
+    // Seed rating + decommission via REST; drive replacement add/remove via UI.
+    await ms.saveRating(ctx, app.id, target.measurableId, "G");
+    const rid = await ms.ratingId(ctx, app.id, target.measurableId);
+    await ms.addDecommission(ctx, rid, "2031-06-01");
+
+    await authenticate(context, token);
+    // Replacement removal uses a native confirm().
+    page.on("dialog", d => d.accept());
+    await ms.openRatingsSection(page, app.id);
+    await ms.enterRatingsEdit(page);
+    await ms.selectCategoryTab(page, target.categoryName);
+    await ms.selectMeasurableInTree(page, target.measurableName);
+
+    const decommEditor = page.locator("waltz-planned-decommission-editor");
+    // Add a replacement app: Add (link) -> pick app -> commission date (the field
+    // starts in edit mode) -> Save -> Confirm.
+    await decommEditor.getByText("Add", { exact: true }).click();
+    await decommEditor.locator(".ui-select-match").click();
+    await page.locator("input.ui-select-search:visible").fill(replacement.name);
+    await page.locator(".ui-select-choices-row", { hasText: replacement.name }).first().click();
+    await decommEditor.locator("input").first().fill("2031-07-01");
+    await decommEditor.locator("input").first().press("Escape");
+    await decommEditor.getByRole("button", { name: "Save" }).click();
+    await decommEditor.getByRole("button", { name: "Confirm" }).click();
+
+    // Decommission-with-replacement overlay on the source app's tree.
+    await expect(page.locator(".wmrt-node .fa-hand-o-right").first()).toBeVisible();
+
+    // The replacement app's own tree shows the incoming ("handshake") overlay.
+    // Its leaf is unrated, so expand the tree to reveal the node.
+    await ms.openRatingsSection(page, replacement.id);
+    await ms.expandRatingTree(page);
+    await expect(page.locator(".wmrt-node .fa-handshake-o").first()).toBeVisible();
+
+    // Remove the replacement (back on the source app), overlay reverts.
+    await ms.openRatingsSection(page, app.id);
+    await ms.enterRatingsEdit(page);
+    await ms.selectCategoryTab(page, target.categoryName);
+    await ms.selectMeasurableInTree(page, target.measurableName);
+    await decommEditor.getByText("Remove").first().click();
+    await decommEditor.getByRole("button", { name: "Confirm" }).click();
+    await expect(page.locator(".wmrt-node .fa-hand-o-right")).toHaveCount(0);
+
+    await ctx.dispose();
+});
+
+test("rolls a leaf rating up to its ancestor (inferred relationship)", async ({ page, context }) => {
+    const token = await login(baseURL);
+    const target = await ms.seedRatableTarget(baseURL, token, uniqueName);
+    const app = await createApp(baseURL, token, uniqueName("ms_rollup"));
+    const ctx = await apiContext(baseURL, token);
+    // Rate the concrete leaf only; the abstract Root ancestor is never rated directly.
+    await ms.saveRating(ctx, app.id, target.measurableId, "G");
+
+    // API check: the rating is inferred onto the ancestor (CHILDREN) but absent for EXACT.
+    const childrenHit = await (await ctx.post("/api/measurable-rating/measurable-selector", {
+        data: { entityReference: { kind: "MEASURABLE", id: target.rootId }, scope: "CHILDREN" }
+    })).json();
+    expect(childrenHit.some(r => r.entityReference.id === app.id && r.measurableId === target.measurableId)).toBe(true);
+    const exactHit = await (await ctx.post("/api/measurable-rating/measurable-selector", {
+        data: { entityReference: { kind: "MEASURABLE", id: target.rootId }, scope: "EXACT" }
+    })).json();
+    expect(exactHit.some(r => r.entityReference.id === app.id)).toBe(false);
+
+    // UI check: the ancestor measurable's Ratings section lists the app via roll-up.
+    await authenticate(context, token);
+    await page.goto(`/measurable/${target.rootId}`);
+    // Match the "Ratings" section button exactly (avoid "Assessment Ratings");
+    // section nav names carry a leading space.
+    await page.locator("button").filter({ hasText: /^\s*Ratings\s*$/ }).first().click();
+    await expect(page.getByText(app.name).first()).toBeVisible();
+
+    await ctx.dispose();
+});
+
+/**
+ * Allocations require an allocation scheme tied to the category, but there is NO
+ * REST endpoint to create one (AllocationSchemeEndpoint is read-only) and the
+ * sample data seeds none. The "Allocations" sub-section only appears when a
+ * scheme exists, so add/remove allocations and the allocation icon overlay
+ * cannot be exercised on the ephemeral backend.
+ */
+test.fixme(
+    "adds and removes allocations",
+    async () => {
+        // Blocked: no create endpoint for allocation schemes (allocation-scheme
+        // API is read-only) and none are seeded, so the Allocations editor never
+        // renders. Enable when the environment provides an allocation scheme.
+    }
+);


### PR DESCRIPTION
Sub-task of #6071.

Adds Playwright e2e coverage for the **Measurables** area to the `waltz-e2e` suite. Data is seeded through the Waltz REST API; scenarios are driven and verified through the AngularJS/Svelte UI.

## Coverage
- Add, edit and remove a measurable rating (tree + rating picker).
- Add and update a comment on a rating.
- Add and revoke a planned decommission date, confirming its tree icon overlay.
- Add and remove a replacement application, confirming the decommission-with-replacement and incoming ("handshake") overlays.
- Confirm roll-ups / inferred relationships: a leaf rating appears on its ancestor's Ratings section (and via the CHILDREN selector, but not EXACT).

## Notes
- The sample data has no editable category with a concrete measurable that the test user may rate, so each test seeds its own: grant `TAXONOMY_EDITOR` + `RATING_EDITOR`, create an editable category (auto-creates an abstract Root), then bulk-apply one concrete measurable under the Root.
- Allocations are left as a documented `test.fixme`: they require an allocation scheme tied to the category, but the allocation-scheme API is read-only (no create endpoint) and none are seeded, so the Allocations editor never renders on the ephemeral backend.
- Seeding + shared UI helpers live in `waltz-e2e/tests/helpers/measurable.js`.
