### PR TITLE
7574: Add Playwright e2e coverage for Flows

### DIFF
--- a/waltz-e2e/tests/flow-classification-rule.spec.js
+++ b/waltz-e2e/tests/flow-classification-rule.spec.js
@@ -1,0 +1,188 @@
+import { test, expect } from "@playwright/test";
+import { apiContext, authenticate, createApp, login, uniqueName } from "./helpers/api.js";
+import { updateRoles } from "./helpers/admin.js";
+
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+/**
+ * Flow classification rule creation e2e.
+ *
+ * A flow classification rule categorises data flows and consists of a Subject (the source/target
+ * system), a Scope (the set of systems the rule applies to), an optional Data Type and a
+ * Classification (e.g. "Primary"). Creating one requires the AUTHORITATIVE_SOURCE_EDITOR role
+ * (see FlowClassificationRuleEndpoint#insertRoute), which the seeded `admin` user does not hold,
+ * so it is granted additively via the roles API before driving the UI.
+ *
+ * Setup is seeded via the REST API; the subject app is created with a unique name and the data
+ * type / scope / classification are all chosen dynamically from baseline data (never hard-coded).
+ *
+ * Flow reference: waltz-test-common/.../playwright/flow_classification_rule/RuleCreationTest.java
+ * UI reference: waltz-ng/client/flow-classification-rule/components/summary-list/
+ *               {FlowClassificationRulesPanel,FlowClassificationRuleEditor}.svelte
+ */
+
+/** Read the current user's roles via GET /api/user/whoami. */
+async function whoamiRoles(token) {
+    const ctx = await apiContext(baseURL, token);
+    try {
+        return (await (await ctx.get("/api/user/whoami")).json()).roles || [];
+    } finally {
+        await ctx.dispose();
+    }
+}
+
+/** GET helper returning parsed JSON. */
+async function getJson(token, path, opts) {
+    const ctx = await apiContext(baseURL, token);
+    try {
+        return await (await ctx.get(path, opts)).json();
+    } finally {
+        await ctx.dispose();
+    }
+}
+
+test("create a flow classification rule for an application", async ({ page, context }) => {
+    let token = await login(baseURL);
+
+    // -- grant the create permission additively, then re-login so the UI sees the new
+    // role. LOGICAL_DATA_FLOW_EDITOR is also needed to seed the logical flow (and its
+    // data-type decorator) used later to confirm the rating renders on the flow view.
+    const roles = await whoamiRoles(token);
+    const needed = ["AUTHORITATIVE_SOURCE_EDITOR", "LOGICAL_DATA_FLOW_EDITOR"];
+    if (!needed.every(r => roles.includes(r))) {
+        await updateRoles(
+            baseURL,
+            token,
+            "admin",
+            [...new Set([...roles, ...needed])],
+            "e2e: flow classification rule create");
+        token = await login(baseURL);
+    }
+
+    // -- seed the subject application and pick scope / data type / classification dynamically
+    const app = await createApp(baseURL, token, uniqueName("fcr_app"));
+
+    const orgUnits = await getJson(token, "/api/org-unit");
+    const scope = orgUnits[0];
+    expect(scope, "expected at least one baseline org unit").toBeTruthy();
+
+    const dataTypes = await getJson(token, "/api/data-types");
+    const dataType = dataTypes.find(d => d.concrete && !d.unknown);
+    expect(dataType, "expected a concrete baseline data type").toBeTruthy();
+
+    const classifications = await getJson(token, "/api/flow-classification");
+    const classification = classifications.find(c => c.userSelectable && c.name === "Primary")
+        || classifications.find(c => c.userSelectable);
+    expect(classification, "expected a user-selectable flow classification").toBeTruthy();
+
+    // -- drive the UI
+    await authenticate(context, token);
+    await page.goto("/data-types");
+
+    const list = page.getByTestId("flow-classification-rule-list");
+    await list.getByTestId("create-rule").click();
+
+    // the Svelte editor form has no testid; scope to the form containing the classification field
+    const editor = page.locator("form").filter({ has: page.locator("#classification") });
+    await expect(editor).toBeVisible();
+
+    // classification (select drives the visible direction labels). The option only renders once
+    // the async flow-classification list has loaded, so wait for it before selecting.
+    const classificationSelect = editor.locator("#classification");
+    await expect(classificationSelect.locator("option", { hasText: classification.name })).toHaveCount(1);
+    await classificationSelect.selectOption({ label: classification.name });
+
+    // subject (simple-svelte-autocomplete over applications). The dropdown is populated by a
+    // debounced async search, so wait for the specific option to render before clicking it and
+    // confirm the selection registered (the input reflects the chosen name) before moving on.
+    const subject = editor.locator("#source");
+    await subject.locator("input").fill(app.name);
+    await subject.locator(".autocomplete-list-item", { hasText: app.name }).first().click();
+    await expect(subject.locator("input")).toHaveValue(app.name);
+
+    // scope (autocomplete over org units etc.) — same deterministic pattern as the subject.
+    const scopeField = editor.locator("#scope");
+    await scopeField.locator("input").fill(scope.name);
+    await scopeField.locator(".autocomplete-list-item", { hasText: scope.name }).first().click();
+    await expect(scopeField.locator("input")).toHaveValue(scope.name);
+
+    // data type (tree selector). Typing filters the tree; wait for the matching node button to
+    // render, click it, then confirm the selection switched the panel to the "chosen" view (the
+    // search input is replaced by the selected data-type label).
+    const datatype = editor.locator("#datatype");
+    await datatype.locator("input[type=search]").fill(dataType.name);
+    const dataTypeNode = datatype.getByRole("button", { name: dataType.name, exact: true }).first();
+    await expect(dataTypeNode).toBeVisible();
+    await dataTypeNode.click();
+    await expect(datatype.locator("input[type=search]")).toHaveCount(0);
+    await expect(datatype).toContainText(dataType.name);
+
+    // description is required to enable the submit button
+    await editor.locator("#description").fill("Created by e2e flow classification rule test");
+
+    const submit = editor.locator("button[type=submit]");
+    await expect(submit).toBeEnabled();
+    await submit.click();
+
+    // -- verify: the create panel closes on success (durable signal — the transient "Created rule"
+    // toast auto-dismisses after ~3s so must not be asserted), which also refreshes the rule list;
+    // then confirm persistence via the API.
+    await expect(editor).toBeHidden();
+
+    const allRules = await getJson(token, "/api/flow-classification-rule");
+    const created = allRules.find(r => r.subjectReference?.id === app.id
+        && r.classificationId === classification.id
+        && r.dataTypeId === dataType.id);
+    expect(created, "rule should be persisted with the seeded subject/datatype/classification").toBeTruthy();
+    expect(created.vantagePointReference.id).toBe(scope.id);
+
+    // open the new rule in the table and confirm the detail panel. Filter the grid to the new
+    // rule and wait for its cell to render before clicking it.
+    await list.locator("input[type=search]").first().fill(app.name);
+    const ruleCell = page.locator(".slick-cell", { hasText: app.name }).first();
+    await expect(ruleCell).toBeVisible();
+    await ruleCell.click();
+
+    await expect(page.getByTestId("source")).toContainText(app.name);
+    await expect(page.getByTestId("data-type")).toContainText(dataType.name);
+    await expect(page.getByTestId("scope")).toContainText(scope.name);
+
+    // -- confirm the logical flow view shows the new rating and colour.
+    // Seed a logical flow from the subject (the authoritative source) to a target
+    // within the rule's scope, carrying the rule's data type, then recalculate flow
+    // ratings so the rule is applied to the new flow.
+    const target = await createApp(baseURL, token, uniqueName("fcr_flow_tgt"), scope.id);
+    const ctx = await apiContext(baseURL, token);
+    const lf = await (await ctx.post("/api/logical-flow", {
+        data: {
+            source: { kind: "APPLICATION", id: app.id },
+            target: { kind: "APPLICATION", id: target.id }
+        }
+    })).json();
+    await ctx.post(`/api/data-type-decorator/save/entity/LOGICAL_DATA_FLOW/${lf.id}`, {
+        data: {
+            entityReference: { kind: "LOGICAL_DATA_FLOW", id: lf.id },
+            addedDataTypeIds: [dataType.id],
+            removedDataTypeIds: []
+        }
+    });
+    await ctx.get("/api/flow-classification-rule/recalculate-flow-ratings");
+
+    // The rule rates the flow's data type with the chosen classification (API check) ...
+    await expect
+        .poll(async () => {
+            const decorators = await getJson(token, `/api/data-type-decorator/entity/LOGICAL_DATA_FLOW/${lf.id}`);
+            return decorators.find(d => d.decoratorEntity.id === dataType.id)?.rating;
+        })
+        .toBe(classification.code);
+
+    // ... and the logical flow view renders that data type with the classification's
+    // colour (the FlowRatingCell source polygon is filled with classification.color).
+    await page.goto(`/logical-flow/${lf.id}`);
+    const dtCell = page
+        .locator("li")
+        .filter({ hasText: dataType.name })
+        .filter({ has: page.locator("svg polygon") });
+    await expect(dtCell.locator("polygon").first()).toHaveAttribute("fill", classification.color);
+    await ctx.dispose();
+});

--- a/waltz-e2e/tests/flows.spec.js
+++ b/waltz-e2e/tests/flows.spec.js
@@ -1,0 +1,308 @@
+import { test, expect } from "@playwright/test";
+import { apiContext, authenticate, createApp, login, uniqueName } from "./helpers/api.js";
+import * as flow from "./helpers/flow.js";
+
+const baseURL = process.env.WALTZ_BASE_URL ?? "http://localhost:8080";
+
+/**
+ * Flows area e2e (issue #7574): logical flows, physical flows and lineage.
+ *
+ * Setup is seeded via the REST API (apps, and — where a scenario needs an
+ * existing flow — logical/physical flows too); the AngularJS/Svelte UI is then
+ * driven. Authoring flows needs edit roles the seeded `admin` user lacks, so
+ * flow.grantFlowRoles grants them additively before each test re-logs in so the
+ * UI's cached identity sees them.
+ *
+ * Java references: waltz-test-common/.../helpers/{LogicalFlow,PhysicalFlow,
+ * PhysicalSpec}Helper.java. Endpoints under waltz-web/.../endpoints/api/.
+ */
+
+/** Grant the flow-authoring roles and return a fresh token that carries them. */
+async function loginWithFlowRoles() {
+    let token = await login(baseURL);
+    await flow.grantFlowRoles(baseURL, token);
+    return login(baseURL);
+}
+
+test("create a logical flow between two applications", async ({ page, context }) => {
+    const token = await loginWithFlowRoles();
+    const source = await createApp(baseURL, token, uniqueName("lf_src"));
+    const target = await createApp(baseURL, token, uniqueName("lf_tgt"));
+
+    await authenticate(context, token);
+    await flow.openRegistration(page, source.id);
+
+    // The Route step is the UI path for creating a logical flow (proposals off).
+    await flow.createDownstreamRoute(page, target.name);
+
+    // Verify persistence via the API: a logical flow now runs source -> target.
+    const ctx = await apiContext(baseURL, token);
+    await expect
+        .poll(async () => {
+            const flows = await flow.logicalFlowsForApp(ctx, source.id);
+            return flows.some(f => f.source.id === source.id && f.target.id === target.id);
+        })
+        .toBe(true);
+    await ctx.dispose();
+});
+
+test("register a physical flow on a new logical flow", async ({ page, context }) => {
+    const token = await loginWithFlowRoles();
+    const source = await createApp(baseURL, token, uniqueName("pf_src"));
+    const target = await createApp(baseURL, token, uniqueName("pf_tgt"));
+    const specName = uniqueName("pf_spec");
+
+    await authenticate(context, token);
+    await flow.openRegistration(page, source.id);
+
+    // Walk the wizard: create the route, the spec, the delivery characteristics,
+    // skip data types, then submit.
+    await flow.createDownstreamRoute(page, target.name);
+    await flow.fillSpecification(page, specName);
+    await flow.fillCharacteristics(page);
+    await flow.skipDataTypes(page);
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+
+    // On success the wizard navigates to the physical-flow view page, which shows
+    // the specification we named.
+    await page.waitForURL("**/physical-flow/*");
+    await expect(page.getByText(specName).first()).toBeVisible();
+
+    // Verify persistence via the API: the source app now has a physical flow, and
+    // its specification carries the name entered in the wizard.
+    const ctx = await apiContext(baseURL, token);
+    const flows = await flow.physicalFlowsForApp(ctx, source.id);
+    expect(flows.length).toBeGreaterThan(0);
+    const specs = await Promise.all(
+        flows.map(f => ctx.get(`/api/physical-specification/id/${f.specificationId}`).then(r => r.json()))
+    );
+    expect(specs.some(s => s.name === specName)).toBe(true);
+    await ctx.dispose();
+});
+
+/**
+ * Seed a source app with an outgoing logical + physical flow, so the flow-summary
+ * section has data to export. `orgUnitId` is where createApp places the app (10).
+ */
+async function seedAppWithFlows(token, prefix) {
+    const source = await createApp(baseURL, token, uniqueName(`${prefix}_src`));
+    const target = await createApp(baseURL, token, uniqueName(`${prefix}_tgt`));
+    const lf = await flow.createLogicalFlow(baseURL, token, flow.appRef(source), flow.appRef(target));
+    const pf = await flow.createPhysicalFlow(baseURL, token, {
+        logicalFlowId: lf.id,
+        owningEntityId: source.id,
+        name: uniqueName(`${prefix}_spec`)
+    });
+    return { source, target, logicalFlowId: lf.id, ...pf };
+}
+
+test("export logical flows at application and aggregate scope", async ({ page, context }) => {
+    const token = await loginWithFlowRoles();
+    const { source } = await seedAppWithFlows(token, "exp_lf");
+    const ctx = await apiContext(baseURL, token);
+    const orgUnitId = await flow.orgUnitIdForApp(ctx, source.id);
+
+    await authenticate(context, token);
+
+    // Application scope: the app's Data Flows summary section.
+    await flow.openSection(page, "APPLICATION", source.id, flow.FLOW_SUMMARY_SECTION_ID);
+    const appCsv = await flow.exportViaLink(page, "Export Logical Flows", "csv");
+    expect(appCsv.suggestedFilename()).toMatch(/\.csv$/);
+
+    const appXlsx = await flow.exportViaLink(page, "Export Logical Flows", "xlsx");
+    expect(appXlsx.suggestedFilename()).toMatch(/\.xlsx$/);
+
+    // Aggregate scope: the org unit the seeded app belongs to.
+    await flow.openSection(page, "ORG_UNIT", orgUnitId, flow.FLOW_SUMMARY_SECTION_ID);
+    const aggCsv = await flow.exportViaLink(page, "Export Logical Flows", "csv");
+    expect(aggCsv.suggestedFilename()).toMatch(/\.csv$/);
+
+    const aggXlsx = await flow.exportViaLink(page, "Export Logical Flows", "xlsx");
+    expect(aggXlsx.suggestedFilename()).toMatch(/\.xlsx$/);
+    await ctx.dispose();
+});
+
+test("export physical flows at application and aggregate scope", async ({ page, context }) => {
+    const token = await loginWithFlowRoles();
+    const { source } = await seedAppWithFlows(token, "exp_pf");
+    const ctx = await apiContext(baseURL, token);
+    const orgUnitId = await flow.orgUnitIdForApp(ctx, source.id);
+
+    await authenticate(context, token);
+
+    // Application scope.
+    await flow.openSection(page, "APPLICATION", source.id, flow.FLOW_SUMMARY_SECTION_ID);
+    const appCsv = await flow.exportViaLink(page, "Export Physical Flows", "csv");
+    expect(appCsv.suggestedFilename()).toMatch(/\.csv$/);
+
+    const appXlsx = await flow.exportViaLink(page, "Export Physical Flows", "xlsx");
+    expect(appXlsx.suggestedFilename()).toMatch(/\.xlsx$/);
+
+    // Aggregate scope: the org unit the seeded app belongs to.
+    await flow.openSection(page, "ORG_UNIT", orgUnitId, flow.FLOW_SUMMARY_SECTION_ID);
+    const aggCsv = await flow.exportViaLink(page, "Export Physical Flows", "csv");
+    expect(aggCsv.suggestedFilename()).toMatch(/\.csv$/);
+
+    const aggXlsx = await flow.exportViaLink(page, "Export Physical Flows", "xlsx");
+    expect(aggXlsx.suggestedFilename()).toMatch(/\.xlsx$/);
+    await ctx.dispose();
+});
+
+test("export the data type list as csv and xlsx", async ({ page, context }) => {
+    const token = await login(baseURL);
+
+    await authenticate(context, token);
+    await page.goto("/data-types");
+    await expect(page.locator("#data-types-tree-section")).toBeVisible();
+
+    const csv = await flow.exportViaLink(page, "Export", "csv");
+    expect(csv.suggestedFilename()).toBe("data-types.csv");
+
+    const xlsx = await flow.exportViaLink(page, "Export", "xlsx");
+    expect(xlsx.suggestedFilename()).toBe("data-types.xlsx");
+});
+
+/**
+ * The data type list export (waltz-data-extract-link on /data-types) offers only
+ * csv and xlsx. SVG export exists in Waltz only for rendered SVG diagram
+ * visualisations (waltz-svg-diagram, format="SVG"), not for the data type list,
+ * so the "svg" part of the checklist item has no control to drive in this build.
+ */
+test.fixme("export the data type list as svg", async () => {
+    // Blocked: no SVG export control on the data type list page; only csv/xlsx are
+    // offered. Enable if/when the data type list gains an SVG (tree) export.
+});
+
+/**
+ * Deleting a logical flow that still has physical flows is NOT prevented on this
+ * build: LogicalFlowService.removeFlow cascades (the view warns "any physical
+ * flows that are attached to the flow will also be removed"). The prevent-delete
+ * behaviour lives on the unmerged branch waltz-1762-prevent-log-flow-delete-if-
+ * physical, so there is nothing to assert here yet.
+ */
+test.fixme("prevent deletion of a logical flow that has physical flows", async () => {
+    // Blocked: master cascades physical-flow removal instead of blocking the
+    // logical-flow delete. Enable once the prevent-delete guard (waltz-1762) lands.
+});
+
+/**
+ * Deleting a physical flow that is used in a lineage is NOT prevented on this
+ * build: the physical-flow view's guard (ctrl.mentions -> disabled Delete +
+ * "cannot be deleted as it is being used in a lineage" popover) is dead — the
+ * lineage-contribution loader that populated `mentions` was removed, so it is
+ * always undefined and never disables the button. PhysicalFlowService.delete has
+ * no lineage check either, so the delete simply proceeds.
+ */
+test.fixme("prevent deletion of a physical flow used in a lineage", async () => {
+    // Blocked: the used-in-a-lineage delete guard is dead code (mentions is never
+    // populated) and unenforced server-side. Enable when the guard is restored.
+});
+
+test("create a lineage (flow diagram) for an application", async ({ page, context }) => {
+    const token = await loginWithFlowRoles();
+    const app = await createApp(baseURL, token, uniqueName("lin_app"));
+    const name = uniqueName("lineage");
+
+    await authenticate(context, token);
+    // "Create new flow diagram" prompts for the name via a native dialog.
+    page.once("dialog", d => d.accept(name));
+    await flow.openSection(page, "APPLICATION", app.id, flow.DIAGRAMS_SECTION_ID);
+    await page.getByText("Create new flow diagram").click();
+
+    // On success the app navigates to the new diagram; verify via the API.
+    await page.waitForURL("**/flow-diagram/*");
+    const ctx = await apiContext(baseURL, token);
+    await expect
+        .poll(async () => {
+            const diagrams = await flow.flowDiagramsForEntity(ctx, "APPLICATION", app.id);
+            return diagrams.some(d => d.name === name);
+        })
+        .toBe(true);
+    await ctx.dispose();
+});
+
+test("edit a lineage's name", async ({ page, context }) => {
+    const token = await loginWithFlowRoles();
+    const app = await createApp(baseURL, token, uniqueName("lin_edit_app"));
+    const diagramId = await flow.createFlowDiagram(baseURL, token, "APPLICATION", app.id, uniqueName("lineage"));
+    const newName = uniqueName("renamed");
+
+    await authenticate(context, token);
+    await flow.openDiagram(page, diagramId);
+    await flow.enterDiagramEdit(page);
+
+    await page.locator("#name").fill(newName);
+    await page.locator(".context-menu").getByRole("button", { name: "Save" }).click();
+
+    const ctx = await apiContext(baseURL, token);
+    await expect.poll(async () => (await flow.getFlowDiagram(ctx, diagramId)).name).toBe(newName);
+    await ctx.dispose();
+});
+
+test("add a physical flow to an existing lineage", async ({ page, context }) => {
+    const token = await loginWithFlowRoles();
+    const { source, target, logicalFlowId, physicalFlowId } = await seedAppWithFlows(token, "lin_add");
+
+    // Seed a diagram holding both app nodes and the logical flow (so the flow
+    // bucket renders on the canvas), but NOT the physical flow decoration yet.
+    const diagramId = await flow.saveFlowDiagram(baseURL, token, {
+        name: uniqueName("lineage"),
+        entities: [
+            { entityReference: { kind: "APPLICATION", id: source.id }, isNotable: false },
+            { entityReference: { kind: "APPLICATION", id: target.id }, isNotable: false },
+            { entityReference: { kind: "LOGICAL_DATA_FLOW", id: logicalFlowId } }
+        ],
+        positions: {
+            [`APPLICATION/${source.id}`]: { x: 200, y: 150 },
+            [`APPLICATION/${target.id}`]: { x: 600, y: 150 }
+        }
+    });
+
+    await authenticate(context, token);
+    await flow.openDiagram(page, diagramId);
+
+    // Select the logical flow on the canvas (stays in VIEW mode so the Context tab,
+    // and hence the FlowPanel, is shown). The FlowPanel's own Edit -> Edit physical
+    // flows opens the picker; the header Edit (overview) is deliberately avoided.
+    await page.locator(`g[data-flow-id="LOGICAL_DATA_FLOW/${logicalFlowId}"] .wfd-flow-bucket`).click();
+    const flowPanel = page.locator(".context-menu .wt-tab.wt-active");
+    await flowPanel.getByRole("button", { name: "Edit" }).click();
+    await flowPanel.getByRole("button", { name: "Edit physical flows" }).click();
+    await flowPanel.locator("input[type=checkbox]").first().check();
+    await flowPanel.getByRole("button", { name: "Update flows" }).click();
+
+    // Persist the canvas changes (the inline "save" appears once the diagram is dirty).
+    await page.locator(".context-menu").getByRole("button", { name: "save" }).click();
+
+    // Verify: the physical flow is now referenced by a flow-diagram entity (lineage).
+    const ctx = await apiContext(baseURL, token);
+    await expect
+        .poll(async () => {
+            const rows = await flow.flowDiagramEntitiesForEntity(ctx, "PHYSICAL_FLOW", physicalFlowId);
+            return rows.length;
+        })
+        .toBeGreaterThan(0);
+    await ctx.dispose();
+});
+
+test("delete a lineage", async ({ page, context }) => {
+    const token = await loginWithFlowRoles();
+    const app = await createApp(baseURL, token, uniqueName("lin_del_app"));
+    const diagramId = await flow.createFlowDiagram(baseURL, token, "APPLICATION", app.id, uniqueName("lineage"));
+
+    await authenticate(context, token);
+    await flow.openDiagram(page, diagramId);
+
+    // Remove (context panel) -> confirm in the in-panel prompt (danger button).
+    await page.locator(".context-menu").getByRole("button", { name: "Remove" }).click();
+    await page.locator(".context-menu").locator("button.btn-danger", { hasText: "Remove" }).click();
+
+    const ctx = await apiContext(baseURL, token);
+    await expect
+        .poll(async () => {
+            const diagrams = await flow.flowDiagramsForEntity(ctx, "APPLICATION", app.id);
+            return diagrams.some(d => d.id === diagramId);
+        })
+        .toBe(false);
+    await ctx.dispose();
+});

--- a/waltz-e2e/tests/helpers/admin.js
+++ b/waltz-e2e/tests/helpers/admin.js
@@ -1,0 +1,154 @@
+import { request } from "@playwright/test";
+import { apiContext } from "./api.js";
+
+/**
+ * Admin-area setup helpers, seeding via the same REST endpoints the UI uses.
+ * See waltz-web/.../endpoints/api/{UserEndpoint,RoleEndpoint,ActorEndpoint}.java
+ */
+
+/** Register a new user via POST /api/user/new-user. */
+export async function createUser(baseURL, token, userName, password) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.post("/api/user/new-user", {
+        data: { userName, password }
+    });
+    if (!resp.ok()) {
+        throw new Error(`create user failed: ${resp.status()} ${await resp.text()}`);
+    }
+    await ctx.dispose();
+    return { userName, password };
+}
+
+/** Set the full role set for a user via POST /api/user/:userName/roles. */
+export async function updateRoles(baseURL, token, userName, roles, comment = "e2e") {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.post(`/api/user/${encodeURIComponent(userName)}/roles`, {
+        data: { roles, comment }
+    });
+    if (!resp.ok()) {
+        throw new Error(`update roles failed: ${resp.status()} ${await resp.text()}`);
+    }
+    await ctx.dispose();
+}
+
+/** Read a user (incl. its roles) via GET /api/user/user-id/:userId. */
+export async function getUser(baseURL, token, userName) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.get(`/api/user/user-id/${encodeURIComponent(userName)}`);
+    if (!resp.ok()) {
+        throw new Error(`get user failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body;
+}
+
+/** All roles (system + custom) via GET /api/role. */
+export async function getRoles(baseURL, token) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.get("/api/role");
+    if (!resp.ok()) {
+        throw new Error(`get roles failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body;
+}
+
+/** All rating schemes via GET /api/rating-scheme. */
+export async function getRatingSchemes(baseURL, token) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.get("/api/rating-scheme");
+    if (!resp.ok()) {
+        throw new Error(`get rating schemes failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body;
+}
+
+/** All assessment definitions via GET /api/assessment-definition. */
+export async function getAssessmentDefinitions(baseURL, token) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.get("/api/assessment-definition");
+    if (!resp.ok()) {
+        throw new Error(`get assessment definitions failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body;
+}
+
+/** Create an actor via POST /api/actor/update (requires ACTOR_ADMIN); returns the new id. */
+export async function createActor(baseURL, token, name, description = "e2e") {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.post("/api/actor/update", {
+        data: { name, description, isExternal: false }
+    });
+    if (!resp.ok()) {
+        throw new Error(`create actor failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const id = await resp.json();
+    await ctx.dispose();
+    return id;
+}
+
+/** All actors via GET /api/actor. */
+export async function getActors(baseURL, token) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.get("/api/actor");
+    if (!resp.ok()) {
+        throw new Error(`get actors failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body;
+}
+
+/** Delete an actor via DELETE /api/actor/:id (requires ACTOR_ADMIN); returns the boolean result. */
+export async function deleteActor(baseURL, token, id) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.delete(`/api/actor/${id}`);
+    if (!resp.ok()) {
+        throw new Error(`delete actor failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body;
+}
+
+/** All end-user applications (EUDAs) via GET /api/end-user-application. */
+export async function getEndUserApps(baseURL, token) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.get("/api/end-user-application");
+    if (!resp.ok()) {
+        throw new Error(`get end-user-apps failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body;
+}
+
+/** Create a static panel via POST /api/static-panel (requires ADMIN). */
+export async function createStaticPanel(baseURL, token, panel) {
+    const ctx = await apiContext(baseURL, token);
+    const resp = await ctx.post("/api/static-panel", { data: panel });
+    if (!resp.ok()) {
+        throw new Error(`create static panel failed: ${resp.status()} ${await resp.text()}`);
+    }
+    await ctx.dispose();
+}
+
+/** Log in as an arbitrary user (not just admin) and return a JWT bearer token. */
+export async function loginAs(baseURL, userName, password) {
+    const ctx = await request.newContext({ baseURL });
+    const resp = await ctx.post("/authentication/login", {
+        data: { userName, password }
+    });
+    if (!resp.ok()) {
+        throw new Error(`login as ${userName} failed: ${resp.status()} ${await resp.text()}`);
+    }
+    const body = await resp.json();
+    await ctx.dispose();
+    return body.token;
+}

--- a/waltz-e2e/tests/helpers/flow.js
+++ b/waltz-e2e/tests/helpers/flow.js
@@ -1,0 +1,325 @@
+import { expect } from "@playwright/test";
+import { apiContext } from "./api.js";
+import { updateRoles } from "./admin.js";
+
+/**
+ * Flow-area REST seeding + query helpers (logical flows, physical specifications,
+ * physical flows and lineage / flow diagrams).
+ *
+ * Authoring flows is permission-gated:
+ *   - logical flow add/remove and attaching a physical flow resolve to LOGICAL flow
+ *     edit rights, granted wholesale by LOGICAL_DATA_FLOW_EDITOR
+ *     (see LogicalFlowDao.calculateAmendedFlowOperations);
+ *   - a bundled physical specification needs PHYSICAL_SPECIFICATION_EDITOR;
+ *   - a lineage (flow diagram) save/delete needs LINEAGE_EDITOR
+ *     (see FlowDiagramEndpoint).
+ * Role checks read the live USER_ROLE table per request, so API seeding needs no
+ * re-login; the UI caches the identity at login, so re-login before driving it.
+ *
+ * Java references (authoritative payload recipes):
+ *   waltz-test-common/.../helpers/{LogicalFlowHelper,PhysicalFlowHelper,PhysicalSpecHelper}.java
+ * Endpoints:
+ *   waltz-web/.../endpoints/api/{LogicalFlowEndpoint,PhysicalFlowEndpoint,FlowDiagramEndpoint}.java
+ */
+
+export const FLOW_ROLES = [
+    "LOGICAL_DATA_FLOW_EDITOR",
+    "PHYSICAL_SPECIFICATION_EDITOR",
+    "LINEAGE_EDITOR"
+];
+
+/** An APPLICATION entity reference from a createApp result (or {id, name}). */
+export function appRef(app) {
+    return { kind: "APPLICATION", id: app.id, name: app.name };
+}
+
+/**
+ * Grant the flow-authoring roles additively (union with the user's current roles;
+ * the roles endpoint replaces the whole set). Caller should re-login afterwards so
+ * the UI's cached identity picks up the new roles before it is driven.
+ */
+export async function grantFlowRoles(baseURL, token, extra = []) {
+    const ctx = await apiContext(baseURL, token);
+    let roles;
+    try {
+        const who = await (await ctx.get("/api/user/whoami")).json();
+        roles = [...new Set([...(who.roles || []), ...FLOW_ROLES, ...extra])];
+    } finally {
+        await ctx.dispose();
+    }
+    await updateRoles(baseURL, token, "admin", roles, "waltz-e2e flow tests");
+}
+
+/** Create a logical flow between two entity references via POST /api/logical-flow. */
+export async function createLogicalFlow(baseURL, token, source, target) {
+    const ctx = await apiContext(baseURL, token);
+    try {
+        const resp = await ctx.post("/api/logical-flow", { data: { source, target } });
+        if (!resp.ok()) {
+            throw new Error(`create logical flow failed: ${resp.status()} ${await resp.text()}`);
+        }
+        return resp.json();
+    } finally {
+        await ctx.dispose();
+    }
+}
+
+/**
+ * Create a physical flow (and its bundled physical specification) via
+ * POST /api/physical-flow. The command embeds a full PhysicalSpecification with a
+ * null id, so the server creates the spec and the flow together. Returns
+ * {physicalFlowId, specificationId, response}.
+ */
+export async function createPhysicalFlow(baseURL, token, { logicalFlowId, owningEntityId, name, dataTypeIds = [] }) {
+    const ctx = await apiContext(baseURL, token);
+    try {
+        const resp = await ctx.post("/api/physical-flow", {
+            data: {
+                specification: {
+                    externalId: name,
+                    owningEntity: { kind: "APPLICATION", id: owningEntityId },
+                    name,
+                    description: "waltz-e2e physical flow",
+                    format: "UNKNOWN",
+                    lastUpdatedBy: "admin",
+                    isRemoved: false,
+                    created: { by: "admin", at: new Date().toISOString().slice(0, 23) }
+                },
+                logicalFlowId,
+                flowAttributes: {
+                    transport: "UNKNOWN",
+                    description: "",
+                    basisOffset: 1,
+                    criticality: "MEDIUM",
+                    frequency: "DAILY"
+                },
+                dataTypeIds
+            }
+        });
+        if (!resp.ok()) {
+            throw new Error(`create physical flow failed: ${resp.status()} ${await resp.text()}`);
+        }
+        const body = await resp.json();
+        return {
+            physicalFlowId: body.entityReference.id,
+            specificationId: body.specificationId,
+            response: body
+        };
+    } finally {
+        await ctx.dispose();
+    }
+}
+
+/** The logical flows touching an application via GET /api/logical-flow/entity/APPLICATION/:id. */
+export async function logicalFlowsForApp(ctx, appId) {
+    return (await ctx.get(`/api/logical-flow/entity/APPLICATION/${appId}`)).json();
+}
+
+/** The physical flows touching an application via GET /api/physical-flow/entity/APPLICATION/:id. */
+export async function physicalFlowsForApp(ctx, appId) {
+    return (await ctx.get(`/api/physical-flow/entity/APPLICATION/${appId}`)).json();
+}
+
+/** The physical flows for a specification via GET /api/physical-flow/specification/:id. */
+export async function physicalFlowsForSpec(ctx, specId) {
+    return (await ctx.get(`/api/physical-flow/specification/${specId}`)).json();
+}
+
+/** The organisational unit an application belongs to (for aggregate-scope views). */
+export async function orgUnitIdForApp(ctx, appId) {
+    const app = await (await ctx.get(`/api/app/id/${appId}`)).json();
+    return app.organisationalUnitId;
+}
+
+/** A concrete, known data type from the baseline taxonomy (GET /api/data-types). */
+export async function firstConcreteDataType(ctx) {
+    const dataTypes = await (await ctx.get("/api/data-types")).json();
+    return dataTypes.find(d => d.concrete && !d.unknown);
+}
+
+// --- UI helpers: the "Register Physical Flow" wizard ------------------------
+//
+// When data-flow proposals are disabled (the default) the wizard at
+// main.physical-flow.registration is the UI path for creating a logical flow
+// (Route step) and then a physical flow (Specification -> Delivery -> Data
+// Types -> Create). Each completed step collapses to a read-only summary, so the
+// duplicated `#name` inputs across steps are never simultaneously present; the
+// EnumSelect selects (#FormatKind / #TransportKind / ...) are unique per page.
+// See waltz-ng/client/physical-flows/svelte/{PhysicalFlowRegistrationView,
+// LogicalFlowSelectionStep,FlowCreator,PhysicalSpecificationStep,
+// PhysicalFlowCharacteristicsStep,DataTypeSelectionStep}.svelte.
+
+/** Open the physical-flow registration wizard for an application (as its source). */
+export async function openRegistration(page, appId) {
+    await page.goto(`/physical-flow/registration/APPLICATION/${appId}`);
+    await expect(page.getByText("Register new Physical Flow").first()).toBeVisible();
+}
+
+/** The `.selection-step` block whose StepHeader carries the given label. */
+function step(page, label) {
+    return page.locator(".selection-step").filter({ hasText: label });
+}
+
+/**
+ * Route step: create a new downstream logical flow to `targetName` (an app/actor
+ * already searchable by name). Leaves the route "Selected".
+ */
+export async function createDownstreamRoute(page, targetName) {
+    const route = step(page, "Route");
+    await route.getByRole("button", { name: "create a new downstream" }).click();
+
+    const targetField = route.locator("#target");
+    await targetField.locator("input").first().fill(targetName);
+    await targetField.locator(".autocomplete-list-item", { hasText: targetName }).first().click();
+
+    await route.getByRole("button", { name: "Create new flow" }).click();
+    await expect(route.getByText("Selected Route:")).toBeVisible();
+}
+
+/** Specification step: create a new spec with the given name and first format. */
+export async function fillSpecification(page, name) {
+    const spec = step(page, "Specification");
+    await spec.locator("#name").fill(name);
+    await spec.locator("#FormatKind").selectOption({ index: 0 });
+    await spec.getByRole("button", { name: "Done" }).click();
+    await expect(spec.getByText(`Selected Specification: ${name}`)).toBeVisible();
+}
+
+/** Delivery Characteristics step: pick the mandatory transport/frequency/criticality. */
+export async function fillCharacteristics(page) {
+    const chars = step(page, "Delivery Characteristics");
+    await chars.locator("#TransportKind").selectOption({ index: 0 });
+    await chars.locator("#FrequencyKind").selectOption({ index: 0 });
+    await chars.locator("#CriticalityKind").selectOption({ index: 0 });
+    await chars.getByRole("button", { name: "Done" }).click();
+    await expect(chars.getByText("Selected Characteristics:")).toBeVisible();
+}
+
+/** Data Types step: skip (allowed when proposals are disabled). */
+export async function skipDataTypes(page) {
+    const dt = step(page, "Data Types");
+    await dt.getByRole("button", { name: "Skip" }).click();
+}
+
+// --- Exports ---------------------------------------------------------------
+//
+// Both application-scoped and aggregate (org-unit / app-group) flow exports are
+// rendered by the "Data Flows" summary dynamic-section (logical-flows-tabgroup-
+// section, section id 14); the data-type list export lives on the /data-types
+// home page. Each control is a waltz-data-extract-link whose no-format variant
+// is a dropdown (Export as csv / xlsx) that downloads client-side via a blob
+// anchor (see widgets/data-extract-link + common/file-utils#downloadFile).
+
+/** Dynamic-section id for the "Data Flows" summary (logical + physical export). */
+export const FLOW_SUMMARY_SECTION_ID = 14;
+
+/** Dynamic-section id for the "Diagrams" section (Linked Diagrams tab is default). */
+export const DIAGRAMS_SECTION_ID = 12;
+
+/** Open an entity's embedded dynamic section (isolates a single panel). */
+export async function openSection(page, kind, id, sectionId) {
+    await page.goto(`/embed/internal/${kind}/${id}/${sectionId}`);
+}
+
+/**
+ * Trigger an export from the waltz-data-extract-link with the given visible name
+ * and return the resulting Playwright download. The dropdown menu is appended to
+ * <body>, so the menu item is matched by visibility rather than by DOM ancestry.
+ */
+export async function exportViaLink(page, linkName, format = "csv") {
+    const link = page.locator("waltz-data-extract-link").filter({ hasText: linkName });
+    await link.locator("[uib-dropdown-toggle], a").first().click();
+    const download = page.waitForEvent("download");
+    await page.getByText(`Export as ${format}`).filter({ visible: true }).click();
+    return download;
+}
+
+// --- Lineage (flow diagrams) ----------------------------------------------
+//
+// Waltz models "lineage" as a flow diagram (LINEAGE_EDITOR role, api/flow-diagram).
+// Endpoints (see FlowDiagramEndpoint / FlowDiagramEntityEndpoint):
+//   POST   api/flow-diagram/entity/:kind/:id   (raw name body) -> new diagram id
+//   GET    api/flow-diagram/id/:id
+//   GET    api/flow-diagram/entity/:kind/:id
+//   POST   api/flow-diagram                    (SaveDiagramCommand) -> diagram id
+//   DELETE api/flow-diagram/id/:id
+//   GET    api/flow-diagram-entity/entity/:kind/:id
+
+/** Create a (named, persisted) flow diagram for an entity. Returns its id. */
+export async function createFlowDiagram(baseURL, token, kind, id, name) {
+    const ctx = await apiContext(baseURL, token);
+    try {
+        const resp = await ctx.post(`/api/flow-diagram/entity/${kind}/${id}`, {
+            headers: { "content-type": "text/plain" },
+            data: name
+        });
+        if (!resp.ok()) {
+            throw new Error(`create flow diagram failed: ${resp.status()} ${await resp.text()}`);
+        }
+        return resp.json();
+    } finally {
+        await ctx.dispose();
+    }
+}
+
+/**
+ * Save a flow diagram (create if `diagramId` omitted) holding the given entities.
+ * `entities` are {entityReference:{kind,id}} records (nodes, logical flows and
+ * physical-flow decorations, distinguished only by kind). Returns the diagram id.
+ */
+export async function saveFlowDiagram(baseURL, token, { diagramId, name, description = "", entities = [], positions = {} }) {
+    const ctx = await apiContext(baseURL, token);
+    try {
+        const resp = await ctx.post("/api/flow-diagram", {
+            data: {
+                diagramId,
+                name,
+                description,
+                entities,
+                annotations: [],
+                overlays: [],
+                layoutData: JSON.stringify({ positions, diagramTransform: "translate(0,0) scale(1)" })
+            }
+        });
+        if (!resp.ok()) {
+            throw new Error(`save flow diagram failed: ${resp.status()} ${await resp.text()}`);
+        }
+        return resp.json();
+    } finally {
+        await ctx.dispose();
+    }
+}
+
+/** A flow diagram by id via GET /api/flow-diagram/id/:id. */
+export async function getFlowDiagram(ctx, id) {
+    return (await ctx.get(`/api/flow-diagram/id/${id}`)).json();
+}
+
+/** The flow diagrams referencing an entity via GET /api/flow-diagram/entity/:kind/:id. */
+export async function flowDiagramsForEntity(ctx, kind, id) {
+    return (await ctx.get(`/api/flow-diagram/entity/${kind}/${id}`)).json();
+}
+
+/** The flow-diagram-entity rows referencing an entity (its lineage memberships). */
+export async function flowDiagramEntitiesForEntity(ctx, kind, id) {
+    return (await ctx.get(`/api/flow-diagram-entity/entity/${kind}/${id}`)).json();
+}
+
+// --- UI helpers: the flow-diagram (lineage) editor -------------------------
+//
+// The editor is a Svelte island mounted at main.flow-diagram.view
+// (/flow-diagram/{id}); there are no data-testid attributes. The right-hand
+// ContextPanel (div.context-menu) holds the Edit / Clone / Remove controls and,
+// in edit mode, the name/description form (#name, #description) with a Save
+// (button.btn-success[type=submit]). See flow-diagram/components/diagram-svelte/.
+
+/** Open an existing flow diagram and wait for its editor to mount. */
+export async function openDiagram(page, id) {
+    await page.goto(`/flow-diagram/${id}`);
+    await expect(page.locator(".context-menu")).toBeVisible();
+}
+
+/** Enter the diagram's edit mode via the ContextPanel "Edit" button. */
+export async function enterDiagramEdit(page) {
+    await page.locator(".context-menu").getByRole("button", { name: "Edit" }).click();
+}


### PR DESCRIPTION
Adds Playwright e2e coverage for the Flows area (issue #7574): logical flows, physical flows and lineage. Setup is seeded via the REST API; the AngularJS/Svelte UI is then driven. Consistent with the existing `waltz-e2e` suite.

## Coverage

| Checklist item | Status |
|---|---|
| Create a logical flow | ✅ |
| Create a physical flow | ✅ (verifies the spec name on the view + API) |
| Export logical flows (aggregate and application) | ✅ csv + xlsx |
| Export physical flows (aggregate and application) | ✅ csv + xlsx |
| Create / Edit / Delete lineage | ✅ flow-diagram editor |
| Add a new physical flow to an existing lineage | ✅ canvas interaction |
| Export the data type list (csv, xlsx) | ✅ |
| Flow classification rule | ✅ now also confirms the logical flow view shows the rating **and colour** |

## Marked `test.fixme` (documented gaps in the current build, not test shortcuts)

- **Export the data type list as SVG** — the data type list page offers only csv/xlsx; SVG export exists only for rendered SVG diagrams.
- **Prevent deletion of a logical flow that has physical flows** — master cascades (removes attached physical flows) rather than preventing; the guard lives on the unmerged `waltz-1762` branch.
- **Prevent deletion of a physical flow used in a lineage** — the UI guard is dead code (`ctrl.mentions` is never populated) and unenforced server-side.

## Notes

- `tests/helpers/admin.js` is byte-identical to the copy in #7608 (7579-e2e-admin); only `updateRoles` is used here. Kept identical so the two branches merge cleanly.
- Validated locally against both a running instance and the ephemeral containerised runner (`npm run test:e2e`): 10 passed, 3 skipped (the fixmes above).