### PR TITLE
7614: Enable CodeQL SAST scanning (report-only)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+name: CodeQL
+
+# Static analysis (SAST) with GitHub CodeQL. Results are published to the repository's
+# Security > Code scanning alerts, with inline annotations on pull requests.
+#
+# Both languages are analysed with build-mode 'none', so CodeQL extracts the source without
+# running the Maven / jOOQ build:
+#   - java-kotlin            Java backend (no Kotlin in this repo, so 'none' is supported)
+#   - javascript-typescript  waltz-ng frontend (interpreted; no build needed)
+#
+# Mode: report-only. Findings surface as code scanning alerts but do not block merges (no
+# required status check is configured). The gate can be tightened later via branch protection.
+#
+# On fork-based pull requests GitHub withholds the 'security-events: write' token, so the
+# upload step is skipped there; the scan still runs on pushes to master and on the schedule.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly, Monday 06:00 UTC
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes #7614
Supersedes #7615 (Semgrep)

## What

Enables Static Application Security Testing (SAST) using **GitHub CodeQL**, report-only. This is
the static-analysis counterpart to the CVE / dependency (SCA) scanning in #7597.

## Why CodeQL (over the Semgrep proposal in #7615)

- **Native integration:** results publish to **Security > Code scanning alerts** with inline PR
  annotations, instead of a downloadable SARIF artifact that no one sees.
- **Free** for public repositories, strong Java and JavaScript coverage.

## Changes

- Add `.github/workflows/codeql.yml`:
  - Analyses `java-kotlin` and `javascript-typescript`, both with **`build-mode: none`** — CodeQL
    extracts the source without running the Maven / jOOQ build, so CI stays simple and reliable.
    (There is no Kotlin in the repo, so `none` is supported for the Java analysis.)
  - Triggers: push to `master`, pull requests to `master`, and a weekly schedule.
- **Report-only:** findings appear as code scanning alerts but do not block merges (no required
  status check is configured). The gate can be tightened later via branch protection — the same
  staged approach used for SCA in #7597, and the direction of OSPS Baseline VM-06.02.

## Notes

- On fork-based PRs GitHub withholds the `security-events: write` token, so the upload step is
  skipped there; the scan runs fully on pushes to `master` and on the schedule.
- After the first run on `master`, findings will be triaged and tracking issue(s) opened for
  anything real.