### PR TITLE
7613: Add project governance docs and roadmap for FINOS TOC health review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,17 @@ Before making a contribution, please take the following steps:
 
 NOTE: All contributors must have a contributor license agreement (CLA) on file with FINOS before their pull requests will be merged. Please review the FINOS [contribution requirements](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530375/Contribution+Compliance+Requirements) and submit (or have your employer submit) the required CLA before submitting a pull request.
 
+## Project Policies
+
+In addition to the FINOS policies linked above, the Waltz project maintains the following policies:
+
+* [Testing](TESTING.md) — when and how tests run, and test expectations for contributions.
+* [Secrets Management & Credential Rotation](docs/governance/policies/secrets-management.md) — handling of build/CI/release secrets.
+* [Support & End-of-Life](docs/governance/policies/support-and-eol.md) — support scope and security-update duration per release.
+* [Vulnerability Remediation (SCA & SAST)](docs/governance/policies/vulnerability-remediation.md) — how automated security findings are triaged and remediated.
+
+Security vulnerabilities are reported and handled per [`SECURITY.md`](SECURITY.md) (FINOS responsible disclosure).
+
 ## Governance
 
 ### Roles

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,14 +6,14 @@ This file lists the maintainers of this repository.
 
 | GitHub Username | Name | Organization | Email |
 |----------------|------|--------------|-------|
-| @MarkGuerriero | *please add name* | *please add organization* | *please add email* |
-| @davidwatkins73 | David Watkins | *please add organization* | davidwatkins73@gmail.com |
+| @MarkGuerriero | Mark Guerriero | @deutschebank | *please add email* |
+| @davidwatkins73 | David Watkins | @deutschebank | davidwatkins73@gmail.com |
 | @jain-shreyans-db | Shreyans Jain | @deutschebank  | *please add email* |
-| @jessica-woodland-scott | *please add name* | *please add organization* | *please add email* |
-| @kamransaleem | Kamran Saleem |  tbc | kamran@thinkincode.co.uk |
-| @kuldeep-jindal-db | *please add name* | *please add organization* | *please add email* |
+| @jessica-woodland-scott | Jessica Woodland-Scott | @deutschebank | *please add email* |
+| @kamransaleem | Kamran Saleem | Think in Code | kamran@thinkincode.co.uk |
+| @kuldeep-jindal-db | Kuldeep Jindal | @deutschebank | *please add email* |
 | @mayank-d-gupta-db | Mayank Gupta | @deutschebank | *please add email* |
-| @meenakshi-saraf-db | *please add name* | *please add organization* | *please add email* |
+| @meenakshi-saraf-db | Meenakshi Saraf | @deutschebank | *please add email* |
 | @rovats | Rohit Vats | *please add organization* | *please add email* |
 
 For information about maintainer responsibilities and resources, see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,53 @@
+# Waltz Roadmap
+
+> Themes are ordered to (a) sustain the project's FINOS Graduated health signals and (b) reach
+> OSPS Baseline Maturity Level 3. Timeframes are indicative and reviewed each half-year.
+
+## Theme 1 — Security & Compliance (OSPS Baseline Level 3)
+
+Target: satisfy OSPS Baseline Maturity Level 3 (the Graduated bar).
+
+- Branch protection: require at least one non-author human review before merge (OSPS-QA-07).
+- Release integrity: sign releases, publish provenance, and document verification steps (OSPS-DO-03, OSPS-BR-02).
+- Software Bill of Materials (SBOM) attached to releases (OSPS-QA-02.02).
+- Automated SCA + SAST in CI with documented remediation thresholds and blocking policy (OSPS-VM-05, OSPS-VM-06).
+- `SECURITY.md`, threat model / attack-surface analysis (OSPS-SA-03.02), secrets-management policy (OSPS-BR-07.02).
+- Support & EOL policy per release (OSPS-DO-04, OSPS-DO-05).
+
+## Theme 2 — Integration & Extensibility
+
+- **Plugin / module architecture** — explore a plugin model letting adopters extend Waltz over a stable core.
+- **MCP server** — explore an AI-agent interface to the Waltz model, aligned with the FINOS [AI Governance Framework](https://github.com/finos/ai-governance-framework).
+- **FINOS ecosystem interoperability** — explore integrations with complementary projects (e.g. [CALM](https://github.com/finos/architecture-as-code), [CCC](https://github.com/finos/common-cloud-controls), [AIGF](https://github.com/finos/ai-governance-framework)) to aid adoption.
+- Complete and document bulk ingestion / create APIs (applications, servers, databases, flows).
+- Publish an OpenAPI / Swagger specification for the REST surface.
+- Idempotent upsert keyed by external id (imports update rather than duplicate).
+- Extension points / webhooks for downstream synchronisation.
+
+## Theme 3 — Quality & CI
+
+- Grow the Playwright end-to-end suite (now running in CI) across core modules.
+- Publish a documented test policy: when/how tests run, and the expectation that changes add/update tests (OSPS-QA-06).
+- Release automation and a published, predictable release cadence.
+
+## Theme 4 — Platform Modernisation
+
+- Publish a staged migration plan away from AngularJS 1.x (end-of-life) for `waltz-ng`.
+- Deliver the first migration slice; ongoing Java/dependency upgrades.
+
+## Theme 5 — Documentation & Onboarding
+
+- Deployment guides, API documentation, getting-started, and data-model documentation.
+- Governance/maintainers documentation (roles and responsibilities).
+
+## Theme 6 — End-user Features
+
+- Reporting / report-grid enhancements.
+- Assessment and survey UX improvements.
+- Performance improvements on large landscapes.
+
+## Cadence & Governance
+
+- Regular releases on a published cadence.
+- Public roadmap (this document), reviewed each half.
+- Semi-annual FINOS TOC health report and presentation.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-# Atomist Open Source Security Policies and Procedures
+# Waltz Security Policies and Procedures
 
 This document outlines security procedures and general policies for the
 Waltz Open Source project as found on https://github.com/finos/waltz.
@@ -32,12 +32,11 @@ process, involving the following steps:
   * Prepare fixes for all releases still under maintenance. These fixes
     will be released as fast as possible.
   
-## Current Known Vulvnerabilities
+## Known Vulnerabilities
 
-Below is a list of vulnerabilites we are aware of.  
-Each vulnerability is given a Waltz rating based upon how we _know_ the code is used within the Waltz database.
-
-| Vulnerability | Java/JS | Waltz Severity | Status |
-| --- | --- | --- | --- | 
-| h2  | Java | Low | No fix currently available (2023-Q1).  Not severe as only used for in-memory integration testing |
-| sparkframework | Java | Medium | Fix available but breaks Tomcat deployment (2023-Q1) | 
+Known vulnerabilities in Waltz's dependencies are tracked as GitHub issues — currently the backend
+([#7595](https://github.com/finos/waltz/issues/7595)) and frontend/AngularJS
+([#7596](https://github.com/finos/waltz/issues/7596)) dependency debt — and are surfaced by the
+project's dependency/security scanning. See the
+[vulnerability remediation policy](docs/governance/policies/vulnerability-remediation.md) for how
+findings are triaged and remediated, and the repository **Security** tab for advisories.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,35 @@
+# Testing
+
+How and when tests run in Waltz, and what is expected of contributions. This complements the
+contribution rules in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## When and how tests run
+
+- **On every pull request and push:** the `maven-dual-build.yml` GitHub Actions workflow builds the
+  multi-module Maven project and runs the automated test suite (Java integration tests and frontend
+  `waltz-ng` mocha tests; mocha results are published as CI test output).
+- **Locally:** contributors run the suite with the standard Maven build (`mvn verify` / the
+  documented build command) before opening a pull request.
+- **End-to-end:** a Playwright e2e suite (applications, technology, measurables, surveys,
+  assessments, app-groups, flows, …) runs in CI via the `playwright-e2e` job; coverage continues to
+  grow.
+
+## Test expectations for changes
+
+- **Bug fixes** SHOULD include a regression test that fails before the fix and passes after.
+- **New features / significant behaviour changes** MUST add or update automated tests covering the
+  new behaviour. A pull request that materially changes functionality without corresponding tests
+  will be asked to add them before merge.
+- **Refactors** MUST keep the existing suite green; add tests where the refactor exposes a gap.
+- Documentation-only or trivial changes are exempt.
+
+## Coverage & quality
+
+- The project does not enforce a fixed numeric coverage gate today; reviewers assess whether the
+  tests meaningfully exercise the change. Introducing coverage reporting is a candidate roadmap item.
+- Tests MUST be deterministic; flaky tests should be fixed or quarantined with a tracking issue.
+
+## Passing tests before merge
+
+- CI MUST be green before a pull request is merged to `master`. Combined with the non-author review
+  required by `CONTRIBUTING.md` and branch protection, this keeps `master` releasable.

--- a/docs/governance/2026-h2-toc-health-report.md
+++ b/docs/governance/2026-h2-toc-health-report.md
@@ -1,0 +1,119 @@
+# Waltz — Semi-Annual Report, 2026 H2
+
+> FINOS TOC semi-annual health report for Waltz (Graduated). This copy is maintained in-repo for
+> maintainer review; the report is submitted to `finos/technical-oversight-committee`
+> (`project-reports/2026/2026-H2-Waltz.md`) ahead of the TOC review call.
+> Metrics are **LFX Insights numbers of record** (insights.linuxfoundation.org, `finos/waltz`,
+> past 365 days, read 2026-09-09) — the TOC reviews LFX data.
+
+**Project Maintainers:** David Watkins (lead), Mark Guerriero, Shreyans Jain, Jessica
+Woodland-Scott, Kuldeep Jindal, Mayank Gupta, and Meenakshi Saraf — all **Deutsche Bank**;
+Rohit Vats; Kamran Saleem (**Think in Code**).
+_(per `MAINTAINERS.md`; some name/org/email entries there are still being completed.)_
+
+**Repository:** https://github.com/finos/waltz · Lifecycle stage: **Graduated** · License: Apache-2.0
+
+# Project Overview
+
+Waltz is an open-source tool for documenting and visualising an organisation's IT landscape —
+applications, data flows, organisational units, people, technology (servers/databases),
+capabilities/measurables, assessments and surveys. It gives enterprise architects a single,
+queryable model of "what we have, how it connects, and how well it meets our standards",
+aimed at regulated environments such as financial services. Java backend, AngularJS (`waltz-ng`)
+frontend, PostgreSQL, multi-module Maven build.
+
+# Current Status
+
+- **LFX health score 92/100 ("Excellent")** — breakdown: Maintainer Health 40/40, Security &
+  Supply Chain 31/35, Development Activity 21/25. Year-on-year, all headline development indicators
+  are up (commits, pull requests, active contributors, stars, forks — see metrics below).
+- **Lifecycle flagged "Declining" — addressed honestly.** LFX marks the lifecycle *Declining* on a
+  single signal: maintainer activity has slowed over the last six months (9 active maintainers
+  remain; median issue response ~1 day). This is the contributor-concentration risk we name openly
+  below; the annual trend is growth, and our roadmap is weighted to broaden the maintainer base.
+- **Sustained release cadence** — ~monthly releases through the period; latest **1.84.0 (2026-07-14)**;
+  100 tagged releases to date; last release very recent.
+- **Technology domain extended** — new create/ingestion endpoints for server and database information
+  and usage (enables programmatic population of the technology model).
+- **End-to-end test suite** — a Playwright e2e suite is now substantially built and under review:
+  ~85 test cases across 12 functional areas (applications, technology, measurables, surveys,
+  assessments, app-groups, flows and more), landing as one PR per area (#7604–#7612). It runs in CI
+  via the `playwright-e2e` job, which passes — a strong, growing quality/regression signal.
+- **Security scanning enabled (SCA + SAST)** — a combined SCA workflow (OWASP dependency-check for
+  Java + auditjs for the frontend) was added report-only (PR #7597), and GitHub CodeQL SAST
+  (Java + JavaScript) was enabled report-only (PR #7616). SCA surfaced real dependency debt, now
+  tracked in #7595 (backend) and #7596 (frontend) — an honest security-health signal.
+
+# Community & Contribution Metrics
+
+_LFX Insights (`finos/waltz`), past 365 days, read 2026-09-09; deltas vs the prior 365-day period.
+LFX now includes bot activity in development counts._
+
+- **Active contributors:** **34** (up from 28; +21%) — 4 maintainers, 9 reviewers; spanning **6
+  active organizations**.
+- **Contributor concentration:** top 5 contributors account for **58%** of activity (lead ~21%);
+  LFX characterises this as a *moderate spread*. Leading organisations by contribution: HMx Labs
+  (50%), FINOS (40%), Think in Code (7%), Deutsche Bank (1%).
+- **Commits:** **1,992** (up from 1,137; +75%, bot activity now counted).
+- **Pull Requests:** **130 opened, 105 merged** (~120 closed); average merge velocity **5 days**,
+  merge lead time ~4 days.
+- **Issues:** **102 closed** in the window (flat vs prior period), ~27-day average resolution;
+  standing open backlog ~370 (see Challenges).
+- **Releases:** 100 total; latest 1.84.0 (2026-07-14); recent cadence ~monthly.
+- **Popularity (in-window):** +39 new stars, +17 new forks; known adoption among financial-services
+  institutions [add named adopters / case studies if shareable].
+
+# Challenges & Blockers
+
+- **Contributor concentration / bus factor** — this is the project's primary health risk and the
+  reason LFX flags the lifecycle *Declining*: maintainer activity has slowed over the last six months.
+  The distribution is a *moderate spread* (top author ~21%, top 5 = 58%, no single dominant author),
+  and the lead-maintainer cadence has dipped over the period. Mitigation in progress: onboarding
+  additional contributors, adding e2e tests to lower the change-risk barrier for new contributors,
+  and documenting build/onboarding.
+- **OSPS Baseline (Level 3) gaps** — as a Graduated project the target is OSPS Baseline **Maturity
+  Level 3**. Governance/security docs are in place (`SECURITY.md`, `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, `MAINTAINERS.md`), and build CI runs tests. Verified gaps to close this cycle:
+  - **SCA and SAST enabled report-only** (SCA via PR #7597: dependency-check + auditjs; SAST via
+    PR #7616: GitHub CodeQL); remaining work is to make them blocking once the standing backlog is
+    burned down (OSPS-VM-05/06).
+  - No release signing/provenance or verification instructions; no SBOM on releases (OSPS-DO-03, BR-02, QA-02.02).
+  - Documented policies added and linked from `CONTRIBUTING.md` (secrets management, support/EOL
+    per release, SCA/SAST remediation thresholds, testing); governance — roles, non-author review,
+    maintainer qualification/voting — is already documented in `CONTRIBUTING.md`; threat model
+    (OSPS-SA-03.02) in draft.
+  - Branch protection is enabled on `master` with merge restricted to maintainers; the explicit
+    "require non-author approval" rule is being confirmed to fully satisfy OSPS-QA-07.01.
+
+  (See the [OSPS Baseline Level 3 checklist](osps-baseline-l3-checklist.md) for the full
+  control-by-control status.)
+- **Frontend modernisation** — `waltz-ng` runs on AngularJS 1.x (end-of-life). A staged migration
+  plan is needed to manage long-term maintainability and security.
+- **Open-issue backlog** — ~370 open issues; triage and grooming needed.
+
+# Roadmap & Goals for Next 6 Months
+
+- **Close OSPS Baseline Level 3 gaps** — branch protection with required review, release
+  signing/provenance + SBOM, SCA/SAST in CI with documented policies, `SECURITY.md`/threat model,
+  support & EOL policy. (Primary compliance goal.)
+- **Integration & extensibility** — complete and document bulk ingestion/create APIs (apps, servers,
+  databases, flows), publish an OpenAPI spec, and add idempotent external-id upsert.
+- **Quality & CI** — merge the Playwright e2e suite (#7604–#7612, already running via the
+  `playwright-e2e` job) and grow coverage; publish a documented test policy.
+- **Platform modernisation** — publish a staged AngularJS migration plan and begin the first slice;
+  dependency upgrades.
+- **Community** — publish a public `ROADMAP.md`, broaden the maintainer base, and groom the issue backlog.
+
+# TOC Support Needed
+
+- **Lifecycle / compliance guidance** — concrete evidence expectations for OSPS Baseline Level 3 and
+  how LFX Insights scores each control, so we can prioritise the highest-impact gaps.
+- **Security tooling support** — pointers to FINOS/OpenSSF resources for release signing/provenance,
+  SBOM generation, and SCA/SAST setup.
+- **Community growth & marketing** — help broadening the contributor/adopter base and surfacing
+  named adopters, to reduce contribution concentration.
+
+# Additional Information
+
+- Multi-module Maven project; Java backend + AngularJS frontend + PostgreSQL.
+- Upstream: https://github.com/finos/waltz

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,0 +1,29 @@
+# Waltz Governance & Compliance Docs
+
+This directory holds the project's governance, compliance, and health-review documentation.
+It supports Waltz's status as a FINOS **Graduated** project and its work toward
+OSPS Baseline **Maturity Level 3**.
+
+## Contents
+
+- [`2026-h2-toc-health-report.md`](2026-h2-toc-health-report.md) — the H2 2026 FINOS TOC
+  semi-annual health report (metrics of record from LFX Insights).
+- [`osps-baseline-l3-checklist.md`](osps-baseline-l3-checklist.md) — control-by-control OSPS
+  Baseline Level 3 status and gap analysis.
+- [`policies/`](policies/) — project policy documents:
+  - [`secrets-management.md`](policies/secrets-management.md) — secrets & credential rotation (OSPS-BR-07.02).
+  - [`support-and-eol.md`](policies/support-and-eol.md) — support scope & end-of-life per release (OSPS-DO-04/05).
+  - [`vulnerability-remediation.md`](policies/vulnerability-remediation.md) — SCA/SAST remediation thresholds (OSPS-VM-05/06).
+
+Governance (roles, maintainer qualification/voting, non-author review) lives in
+[`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) (OSPS-GV-04, QA-07); testing in
+[`../../TESTING.md`](../../TESTING.md) (OSPS-QA-06). All project policies are linked from
+`CONTRIBUTING.md`.
+
+## Related project docs
+
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) — contribution & governance policies (roles, review, voting).
+- [`../../SECURITY.md`](../../SECURITY.md) — vulnerability reporting (FINOS responsible disclosure).
+- [`../../MAINTAINERS.md`](../../MAINTAINERS.md) — maintainer roster.
+- [`../../TESTING.md`](../../TESTING.md) — testing policy.
+- [`../../ROADMAP.md`](../../ROADMAP.md) — public roadmap.

--- a/docs/governance/osps-baseline-l3-checklist.md
+++ b/docs/governance/osps-baseline-l3-checklist.md
@@ -1,0 +1,87 @@
+# OSPS Baseline — Level 3 Gap Checklist for Waltz (Graduated)
+
+> Source: OpenSSF OSPS Baseline (`github.com/ossf/security-baseline`, `baseline/OSPS-*.yaml`).
+> Graduated projects target **Maturity Level 3**: 63 of 65 controls apply, of which **21 are
+> Level-3-specific** (listed below). The TOC assesses compliance via LFX Insights.
+> Statuses below were verified against `finos/waltz` on 2026-09-04 (audit of repo contents,
+> workflows, release assets). Branch protection on `master` is enabled with merge restricted to
+> maintainers (confirmed by maintainers 2026-09-09).
+> Updated 2026-09-06 for PR #7597 (SCA re-enabled, report-only);
+> 2026-09-09 for the Playwright e2e suite now running in CI (#7604–#7612), CodeQL SAST enabled
+> report-only (#7616), and branch protection confirmed.
+
+## Verified repo audit — headline findings
+
+- ✅ Present: `LICENSE` (Apache-2.0), `SECURITY.md` (FINOS responsible disclosure), `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, `MAINTAINERS.md` (9 maintainers; some placeholder entries), `CONTRIBUTORS.md`.
+- ✅ Build CI active (`maven-dual-build.yml`) runs Maven integration tests + publishes mocha test results.
+- ⚠️ **SCA re-enabled (report-only) via PR #7597** (open, mergeable): one workflow runs OWASP
+  dependency-check (Java) + auditjs (frontend), single combined `cve-reports` artifact. Not yet
+  blocking; findings tracked in #7595 (backend) / #7596 (frontend).
+- ⚠️ **SAST (GitHub CodeQL) enabled (report-only) via PR #7616**: Java + JavaScript, findings in the
+  Security tab + inline PR annotations. Not yet blocking. Making SCA + SAST blocking (once the
+  backlog is burned down) = remaining fast wins.
+- ❌ No `dependabot.yml`. ❌ Releases unsigned, no SBOM (1.84.0 = plain jar/war/zip).
+- ✅ Branch protection enabled on `master`; merge rights restricted to maintainers, changes land via
+  reviewed PRs (confirmed by maintainers 2026-09-09). Confirm the explicit "require non-author
+  approval" rule to fully satisfy OSPS-QA-07.01.
+
+## Level-3-specific requirements (the Graduated-only bar)
+
+### Access Control
+- [ ] **OSPS-AC-04.02** — CI/CD jobs use minimum privileges. ❓ _Assess GitHub Actions `permissions:` blocks._
+
+### Build & Release
+- [ ] **OSPS-BR-01.04** — CI sanitises trusted-collaborator input. ❓ _Assess._
+- [ ] **OSPS-BR-02.02** — Release assets associated with a release/unique id. ⚠️ _Assets exist under tag; no provenance._
+- [x] **OSPS-BR-07.02** — Documented secrets/credential-rotation policy. ✅ _Documented (this PR): `policies/secrets-management.md`._
+
+### Documentation
+- [ ] **OSPS-DO-03.01** — Instructions to verify release integrity/authenticity. ❌ _Gap — needs signing first._
+- [ ] **OSPS-DO-03.02** — Instructions to verify author/process identity. ❌ _Gap._
+- [x] **OSPS-DO-04.01** — Statement of support scope/duration per release. ✅ _Documented (this PR): `policies/support-and-eol.md`._
+- [x] **OSPS-DO-05.01** — Statement of security-update end per release. ✅ _Documented (this PR): `policies/support-and-eol.md`._
+
+### Governance
+- [x] **OSPS-GV-04.01** — Policy: collaborators reviewed before escalated permissions. ✅ _Documented: `CONTRIBUTING.md` (Maintainer Qualifications & Voting)._
+
+### Quality
+- [ ] **OSPS-QA-02.02** — SBOM delivered with release assets. ❌ _Gap — no SBOM on 1.84.0._
+- [ ] **OSPS-QA-04.02** — Multi-repo releases: subprojects ≥ primary security. ➖ _Likely n/a (single repo)._
+- [x] **OSPS-QA-06.02** — Docs state when/how tests run. ✅ _Documented (this PR): `TESTING.md`;
+  Maven ITs + mocha in build CI, Playwright e2e via `playwright-e2e` (#7604–#7612)._
+- [x] **OSPS-QA-06.03** — Policy that major changes add/update tests. ✅ _Documented (this PR): `TESTING.md`._
+- [ ] **OSPS-QA-07.01** — ≥1 non-author approval before merge to `master`. ⚠️ _Documented in
+  `CONTRIBUTING.md` (non-author review) + branch protection enabled, merge restricted to maintainers
+  (2026-09-09). Confirm the "require non-author approval" rule is enforced to fully satisfy._
+
+### Security Assessment
+- [ ] **OSPS-SA-03.02** — Threat model / attack-surface analysis. ❌ _Gap._
+
+### Vulnerability Management
+- [ ] **OSPS-VM-04.02** — VEX for non-affecting component vulns. ❌ _Gap._
+- [x] **OSPS-VM-05.01** — Policy: remediation threshold for SCA findings. ✅ _Documented (this PR): `policies/vulnerability-remediation.md`._
+- [x] **OSPS-VM-05.02** — Policy: address SCA violations before release. ✅ _Documented (this PR): `policies/vulnerability-remediation.md` (release gating)._
+- [ ] **OSPS-VM-05.03** — Automated dependency vuln/malicious-dep eval, blocking. ⚠️ _SCA now runs report-only (PR #7597); make blocking to satisfy._
+- [x] **OSPS-VM-06.01** — Policy: remediation threshold for SAST findings. ✅ _Documented (this PR): `policies/vulnerability-remediation.md`._
+- [ ] **OSPS-VM-06.02** — Automated SAST eval, blocking (with suppression). ⚠️ _CodeQL enabled report-only via #7616; make blocking to satisfy._
+
+## Inherited (Levels 1–2) — status from audit
+- ✅ `LICENSE` Apache-2.0; ✅ `SECURITY.md` reporting process; ✅ `CONTRIBUTING`/`CODE_OF_CONDUCT`;
+  ✅ `MAINTAINERS.md` roles (orgs filled this PR; one org still TBC — OSPS-GV-01); ✅ CI runs on changes.
+- ❓ Confirm: org-wide 2FA, least-privilege access, dependency update mechanism (no Dependabot found).
+
+## Suggested sequencing (highest impact first)
+
+1. **Enforce + extend scanning.** SCA (PR #7597) and CodeQL SAST (PR #7616) now run report-only;
+   remaining fast wins are to make them blocking (once the backlog is burned down) and add
+   `dependabot.yml` (OSPS-VM-05/06).
+2. **Branch protection**: enabled, merge restricted to maintainers; confirm the explicit
+   "require non-author review" rule on `master` (OSPS-QA-07) — also cuts bus-factor risk.
+3. **Policies as docs** — done this PR: secrets, support/EOL, SCA/SAST remediation thresholds
+   (`docs/governance/policies/`), testing (`TESTING.md`); governance/review already in `CONTRIBUTING.md`.
+4. **Release integrity**: sign releases + provenance + verification instructions + SBOM generation.
+5. **Threat model**: attack-surface analysis document (OSPS-SA-03.02).
+
+> With the policy docs landed, the main remaining Level-3 gaps are **release integrity**
+> (signing/provenance/SBOM) and the **threat model**.

--- a/docs/governance/policies/secrets-management.md
+++ b/docs/governance/policies/secrets-management.md
@@ -1,0 +1,52 @@
+# Secrets Management & Credential Rotation Policy
+
+> Project policy satisfying **OSPS-BR-07.02** (documented secrets/credential-rotation policy).
+
+## Scope
+This policy covers all secrets used by the Waltz project's build, test, release, and CI/CD
+infrastructure. It does **not** cover secrets held by downstream deployers of Waltz — those are
+the operator's responsibility (see the deployment documentation).
+
+In-scope secrets include, but are not limited to:
+
+- GitHub Actions organisation/repository secrets (e.g. `NVD_API_KEY`, `OSSINDEX_USER`,
+  `OSSINDEX_TOKEN` used by CVE scanning; any publish/deploy credentials).
+- Any package-registry, artifact-signing, or release-publishing credentials.
+- Bot or automation tokens (e.g. dependency-update automation).
+
+## Storage
+- Secrets MUST be stored only in GitHub Actions encrypted secrets (repository or organisation
+  scope) or an approved secrets manager. They MUST NOT be committed to the repository, embedded
+  in workflow files, or printed to CI logs.
+- Workflows MUST reference secrets via `${{ secrets.* }}` and MUST NOT echo them. Steps handling
+  secrets SHOULD set `env:` at the narrowest scope needed.
+- Secret scanning (GitHub secret scanning / push protection) SHOULD be enabled on the repository
+  to catch accidental commits.
+
+## Least privilege
+- Each secret MUST be scoped to the smallest set of workflows/jobs that need it.
+- Automation tokens MUST use the minimum permissions required (scoped `permissions:` blocks in
+  workflows — OSPS-AC-04.02).
+
+## Rotation
+- Long-lived credentials MUST be rotated at least **every 12 months**.
+- A secret MUST be rotated **immediately** on any of:
+  - suspected or confirmed exposure (commit, log, screenshot, third-party leak);
+  - departure of a maintainer who had access to it;
+  - deprecation/compromise notice from the issuing provider.
+- Prefer short-lived, automatically-issued credentials (e.g. OIDC-based federation) over
+  long-lived tokens wherever the provider supports it, to reduce rotation burden.
+
+## Ownership & review
+- Each secret has a named maintainer owner responsible for its lifecycle.
+- The maintainers review the inventory of active secrets at least **every 6 months**, removing
+  any that are unused.
+
+## Incident response
+- On suspected exposure: revoke first, rotate, then assess blast radius. Report per the process
+  in `SECURITY.md` (FINOS responsible disclosure) if third parties may be affected.
+
+## Related
+- [`../../../SECURITY.md`](../../../SECURITY.md) (vulnerability reporting) ·
+  [`vulnerability-remediation.md`](vulnerability-remediation.md) ·
+  [`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md)

--- a/docs/governance/policies/support-and-eol.md
+++ b/docs/governance/policies/support-and-eol.md
@@ -1,0 +1,41 @@
+# Support & End-of-Life Policy
+
+> Project policy satisfying **OSPS-DO-04.01** (statement of support scope/duration per release) and
+> **OSPS-DO-05.01** (statement of when security updates end per release).
+> The specific support windows below are proposed for maintainer confirmation.
+
+## Release model
+Waltz follows a rolling release model with `MAJOR.MINOR.PATCH` version numbers and an
+approximately monthly cadence (latest: 1.84.0, 2026-07-14; 100 releases to date). Releases are
+published as jar/war/zip assets under the corresponding Git tag.
+
+## Support scope
+- **Actively supported:** the **latest released version** is the supported baseline. Bug reports,
+  security fixes, and questions are handled against the latest release and `master`.
+- Users are expected to upgrade forward to receive fixes; Waltz does not maintain long-lived
+  parallel maintenance branches for older minor versions.
+- "Support" here means community best-effort via GitHub issues and the FINOS channels — there is
+  no commercial SLA from the project itself.
+
+## Security-update duration
+- Security fixes are delivered in the **next release on `master`**, i.e. against the latest line.
+- Older releases do **not** receive back-ported security patches; the supported remediation is to
+  upgrade to the latest release.
+- Security issues are reported and handled per `SECURITY.md` (FINOS responsible disclosure).
+
+## End-of-life
+- A release reaches practical end-of-life when a newer release supersedes it, because fixes land
+  forward on `master` rather than being back-ported.
+- Any deviation (e.g. a designated long-term-support line, should one ever be created) will be
+  documented explicitly in the release notes and here.
+
+## Platform/runtime support
+- Supported Java, database (PostgreSQL / others), and browser baselines are documented in the
+  project README / deployment docs; those baselines move forward with releases.
+- The AngularJS 1.x frontend is a known end-of-life dependency; its migration is tracked on the
+  public roadmap (see #7596 for the associated security exposure).
+
+## Related
+- [`../../../SECURITY.md`](../../../SECURITY.md) ·
+  [`vulnerability-remediation.md`](vulnerability-remediation.md) ·
+  [`../../../ROADMAP.md`](../../../ROADMAP.md)

--- a/docs/governance/policies/vulnerability-remediation.md
+++ b/docs/governance/policies/vulnerability-remediation.md
@@ -1,0 +1,65 @@
+# Vulnerability Remediation Policy (SCA & SAST)
+
+> Project policy satisfying **OSPS-VM-05.01** (documented remediation threshold for SCA findings),
+> **OSPS-VM-05.02** (address SCA violations before release), and **OSPS-VM-06.01** (documented
+> remediation threshold for SAST findings). Supports the enforcement side of **OSPS-VM-05.03 / VM-06.02**.
+
+## Purpose
+Define how the Waltz maintainers triage and remediate automated security findings so that the
+severity that blocks a release, and the time allowed to fix, are predictable and documented.
+
+Reported (non-automated) vulnerabilities are handled separately, under [`SECURITY.md`](../../../SECURITY.md)
+and the [FINOS Security Vulnerabilities Policy](https://community.finos.org/docs/governance/software-projects/cve-responsible-disclosure/)
+(responsible disclosure). This policy covers the triage and remediation of findings surfaced by the
+project's automated SCA/SAST scanning.
+
+## Tooling
+- **SCA (dependencies):** OWASP dependency-check (Java modules) + auditjs (frontend), combined
+  `cve-reports` artifact — enabled report-only via **#7597**.
+- **SAST (code):** GitHub CodeQL (Java + JavaScript) — enabled **report-only** via **#7616**;
+  findings surface in the repository Security tab and as inline pull-request annotations. Making it
+  blocking is tracked as L3 work.
+- Severity uses **CVSS v3.1** base scores: Critical ≥ 9.0, High 7.0–8.9, Medium 4.0–6.9,
+  Low 0.1–3.9.
+
+## Remediation thresholds & timelines
+Measured from when a finding is first surfaced by CI (or reported per `SECURITY.md`):
+
+| Severity | SCA action | SAST action | Target time to remediate/mitigate |
+|----------|-----------|-------------|-----------------------------------|
+| Critical | Fix, upgrade, or documented mitigation required | Fix or documented false-positive suppression | **30 days** |
+| High     | Fix, upgrade, or documented mitigation required | Fix or suppression | **90 days** |
+| Medium   | Address or accept with rationale | Address or accept | Best effort, next minor |
+| Low      | Track | Track | Best effort |
+
+"Mitigation" includes upgrading the dependency, removing it, applying a configuration that
+removes exploitability, or recording a **VEX** statement where the vulnerability is not
+exploitable in Waltz's usage (OSPS-VM-04.02).
+
+## Release gating
+- No release SHOULD ship with an **unaddressed Critical** SCA or SAST finding. "Addressed" means
+  fixed, mitigated, or accompanied by a documented, time-bound exception approved by a maintainer
+  (with a tracking issue).
+- High findings that cannot be fixed by release time MUST have a tracking issue and a target date.
+- Where a finding stems from an end-of-life upstream framework with no available fix (e.g. Spring
+  5.3.x — #7595; AngularJS stack — #7596), the accepted remediation path is the upgrade/migration
+  tracked on the roadmap; the exception MUST be recorded with that link.
+
+## False positives & suppressions
+- Suppressions MUST be explicit and justified (e.g. a dependency-check suppression file for SCA, or
+  a dismissed CodeQL alert / inline `// codeql[...]` annotation for SAST), and carry a short
+  justification and, where relevant, a review date.
+- Blanket suppression of a whole rule/severity is not permitted without maintainer sign-off.
+
+## Enforcement roadmap
+1. SCA report-only (done — #7597).
+2. CodeQL (SAST) report-only (done — #7616).
+3. Add `dependabot.yml` for automated dependency updates.
+4. Promote SCA/SAST to **blocking** on pull requests once the existing backlog (#7595/#7596) is
+   burned down, satisfying VM-05.03 / VM-06.02.
+
+## Related
+- [`../../../SECURITY.md`](../../../SECURITY.md) ·
+  [`secrets-management.md`](secrets-management.md) ·
+  [`../../../TESTING.md`](../../../TESTING.md) ·
+  [`../../../CONTRIBUTING.md`](../../../CONTRIBUTING.md)


### PR DESCRIPTION
Closes #7613

Ahead of the semi-annual FINOS TOC health review, this adds the supporting governance, compliance and roadmap documentation to the repository so the wider maintainer group can review it, and so it becomes durable, versioned project documentation. It also progresses OSPS Baseline Level 3 work.

## What's included

- **`ROADMAP.md`** (root) — public roadmap, organised around sustaining Graduated health signals and reaching OSPS Baseline Level 3.
- **`TESTING.md`** (root) — when/how tests run and test expectations for contributions (OSPS-QA-06).
- **`docs/governance/`**
  - `2026-h2-toc-health-report.md` — the H2 2026 TOC health report (metrics of record from LFX Insights), kept in-repo for maintainer review; it is submitted separately to `finos/technical-oversight-committee`.
  - `osps-baseline-l3-checklist.md` — control-by-control OSPS Baseline Level 3 status.
  - `policies/` — project policies: secrets management (BR-07.02), support & end-of-life (DO-04/05), vulnerability remediation (VM-05/06).
- **`CONTRIBUTING.md`** — new *Project Policies* section linking the above (governance itself already lives here — roles, review, maintainer voting).
- **`MAINTAINERS.md`** — filled in maintainer organisation entries.
- **`SECURITY.md`** — corrected the title, removed a stale (2023) known-vulnerabilities table in favour of tracked issues + the Security tab, and linked the vulnerability remediation policy.

## Notes

- Scope deliberately follows FINOS conventions: governance stays in `CONTRIBUTING.md`, security disclosure stays in `SECURITY.md` (FINOS policy), and only genuinely project-specific policies are added — no duplication.
- Roadmap items for a plugin/module architecture, an MCP server, and FINOS ecosystem interoperability are intentionally exploratory.